### PR TITLE
fix: connect all frontend components with routing and API client

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# shokudo-nexus frontend environment variables
+VITE_API_URL=http://localhost:8080

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -3,13 +3,27 @@ import { describe, expect, it } from "vitest";
 import { App } from "./App";
 
 describe("App", () => {
-	it("renders the heading", () => {
+	it("renders the heading on home page", () => {
 		render(<App />);
 		expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("shokudo-nexus");
 	});
 
-	it("renders the description", () => {
+	it("renders the description on home page", () => {
 		render(<App />);
 		expect(screen.getByText("余剰食品と子ども食堂のマッチングプラットフォーム")).toBeDefined();
+	});
+
+	it("renders navigation links", () => {
+		render(<App />);
+		expect(screen.getByRole("link", { name: "食品登録" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "在庫一覧" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "融通リクエスト" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "融通一覧" })).toBeInTheDocument();
+	});
+
+	it("renders home page cards linking to food and fusion", () => {
+		render(<App />);
+		expect(screen.getByText("在庫管理")).toBeInTheDocument();
+		expect(screen.getByText("食材融通")).toBeInTheDocument();
 	});
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,27 @@
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { FoodItemForm } from "@/components/food/FoodItemForm";
+import { FoodItemList } from "@/components/food/FoodItemList";
+import { FusionRequestForm } from "@/components/fusion/FusionRequestForm";
+import { FusionRequestList } from "@/components/fusion/FusionRequestList";
+import { HomePage } from "@/components/HomePage";
+import { AppLayout } from "@/components/layout/AppLayout";
+import { ApiClientProvider } from "@/lib/api-context";
+import { mockApiClient } from "@/lib/mock-api-client";
+
 export function App(): React.ReactElement {
 	return (
-		<div>
-			<h1>shokudo-nexus</h1>
-			<p>余剰食品と子ども食堂のマッチングプラットフォーム</p>
-		</div>
+		<ApiClientProvider client={mockApiClient}>
+			<BrowserRouter>
+				<Routes>
+					<Route element={<AppLayout />}>
+						<Route index element={<HomePage />} />
+						<Route path="food" element={<FoodItemList />} />
+						<Route path="food/new" element={<FoodItemForm />} />
+						<Route path="fusion" element={<FusionRequestList />} />
+						<Route path="fusion/new" element={<FusionRequestForm />} />
+					</Route>
+				</Routes>
+			</BrowserRouter>
+		</ApiClientProvider>
 	);
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import "./styles.css";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- App.tsx was a bare stub rendering only `<h1>` + `<p>`, leaving all components (FoodItemForm, FoodItemList, FusionRequestForm, FusionRequestList, HomePage, AppLayout) orphaned and unreachable
- Wired up BrowserRouter + Routes with AppLayout as the layout route, placing all existing components at their expected paths (`/`, `/food`, `/food/new`, `/fusion`, `/fusion/new`)
- Wrapped the entire app in ApiClientProvider with mockApiClient so all hooks (useFoodItems, useFusionRequests) can access the API context
- Added `styles.css` import in main.tsx with `vite-env.d.ts` for TypeScript CSS module support
- Added `frontend/.env.example` with `VITE_API_URL`

## Test plan
- [x] `make check` passes at root level (backend + frontend + proto lint)
- [x] All 59 frontend tests pass (6 test files)
- [x] All 45 backend tests pass
- [x] App.test.tsx updated to verify routing: heading, description, nav links, home page cards
- [x] lefthook pre-commit hooks pass (archgate, format, lint, test)
- [ ] Manual: open `http://localhost:3000` and verify navigation between all pages
- [ ] Manual: submit food item form and fusion request form, verify mock API is called