### PR TITLE
fix: prevent concurrent double-reservation on fusion approval

### DIFF
--- a/backend/internal/service/fusion.go
+++ b/backend/internal/service/fusion.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -18,6 +19,9 @@ type FusionService struct {
 	pb.UnimplementedFusionServiceServer
 	fusionRepo   repository.FusionRequestStore
 	foodItemRepo repository.FoodItemStore
+	// approvalMu は承認処理のクリティカルセクションを保護し、
+	// 同一在庫の二重予約を防止する。
+	approvalMu sync.Mutex
 }
 
 // NewFusionService は新しいFusionServiceを生成する。
@@ -97,9 +101,17 @@ func (s *FusionService) ListFusionRequests(ctx context.Context, req *pb.ListFusi
 }
 
 // RespondToFusionRequest は融通リクエストに応答する（承認/拒否）。
+// 承認時はMutexでクリティカルセクションを保護し、同一在庫の二重予約を防止する。
 func (s *FusionService) RespondToFusionRequest(ctx context.Context, req *pb.RespondToFusionRequestRequest) (*pb.RespondToFusionRequestResponse, error) {
 	if err := validateRespondToFusionRequest(req); err != nil {
 		return nil, err
+	}
+
+	// 承認処理時は排他制御を行い、同一在庫の二重予約を防止する。
+	// 拒否処理は競合が発生しないため排他不要。
+	if req.GetResponse() == "APPROVED" {
+		s.approvalMu.Lock()
+		defer s.approvalMu.Unlock()
 	}
 
 	fusionReq, err := s.fusionRepo.Get(ctx, req.GetFusionRequestId())

--- a/backend/internal/service/fusion_test.go
+++ b/backend/internal/service/fusion_test.go
@@ -423,6 +423,75 @@ func TestRespondToFusionRequest_ApprovalSetsResponderShokudoID(t *testing.T) {
 	}
 }
 
+func TestRespondToFusionRequest_ConcurrentApprovalPreventsDoubleReservation(t *testing.T) {
+	fusionStore := newMockFusionRequestStore()
+	foodStore := newMockFoodItemStore()
+
+	// 1つの食品に対して2つの融通リクエストが同時に承認されるシナリオ
+	foodItem := &domain.FoodItem{
+		ID:       "food-shared",
+		Category: "野菜",
+		Quantity: 5,
+		Unit:     "kg",
+		DonorID:  "shokudo-X",
+		Status:   domain.FoodItemStatusAvailable,
+	}
+	foodStore.items[foodItem.ID] = foodItem
+
+	fusionReq1 := &domain.FusionRequest{
+		ID:              "req-concurrent-1",
+		DesiredCategory: "野菜",
+		DesiredQuantity: 5,
+		Unit:            "kg",
+		Status:          domain.FusionRequestStatusPending,
+	}
+	fusionReq2 := &domain.FusionRequest{
+		ID:              "req-concurrent-2",
+		DesiredCategory: "野菜",
+		DesiredQuantity: 5,
+		Unit:            "kg",
+		Status:          domain.FusionRequestStatusPending,
+	}
+	fusionStore.requests[fusionReq1.ID] = fusionReq1
+	fusionStore.requests[fusionReq2.ID] = fusionReq2
+
+	svc := NewFusionService(fusionStore, foodStore)
+
+	// 並行実行
+	const goroutines = 2
+	results := make(chan error, goroutines)
+
+	approve := func(reqID string) {
+		_, err := svc.RespondToFusionRequest(context.Background(), &pb.RespondToFusionRequestRequest{
+			FusionRequestId: reqID,
+			Response:        "APPROVED",
+			FoodItemId:      foodItem.ID,
+		})
+		results <- err
+	}
+
+	go approve(fusionReq1.ID)
+	go approve(fusionReq2.ID)
+
+	var successCount, failCount int
+	for range goroutines {
+		err := <-results
+		if err == nil {
+			successCount++
+		} else {
+			failCount++
+		}
+	}
+
+	// Mutex保護により、1つだけ成功し、もう1つはFailedPrecondition（food item already reserved）
+	if successCount != 1 {
+		t.Errorf("expected exactly 1 successful approval, got %d", successCount)
+	}
+	if failCount != 1 {
+		t.Errorf("expected exactly 1 failed approval, got %d", failCount)
+	}
+}
+
 func TestRespondToFusionRequest_FusionUpdateFailRollbacksFoodItem(t *testing.T) {
 	fusionStore := newMockFusionRequestStore()
 	foodStore := newMockFoodItemStore()


### PR DESCRIPTION
## Summary
- FusionService に sync.Mutex を追加し、承認処理のクリティカルセクションを排他制御
- 拒否処理は競合が発生しないためロック対象外（パフォーマンス考慮）
- 並行承認で二重予約が防止されることを検証するテストを追加

## Root Cause
RespondToFusionRequest の承認処理で、FoodItem のステータス確認（available）と更新（reserved）の間に同期が無く、2つの並行リクエストが同一在庫を二重予約できた。

## Test plan
- [x] `TestRespondToFusionRequest_ConcurrentApprovalPreventsDoubleReservation` - 2 goroutine 並行承認で1成功/1失敗
- [x] 既存テスト全パス（ロールバック、バリデーション等に影響なし）
- [x] `make check` 全パス