### PR TITLE
fix: replace hardcoded mockApiClient with api-factory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# gRPC バックエンドの URL。
+# 設定すると gRPC-Web クライアントでバックエンドに接続する。
+# 未設定（コメントアウト）の場合はモック API で動作する。
+# VITE_API_URL=http://localhost:8080

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "shokudo-nexus-frontend",
 			"version": "0.1.0",
 			"dependencies": {
+				"@bufbuild/protobuf": "^1.10.1",
+				"@connectrpc/connect": "^1.7.0",
+				"@connectrpc/connect-web": "^1.7.0",
 				"react": "^19.2.4",
 				"react-dom": "^19.2.4",
 				"react-router-dom": "^7.13.2"
@@ -360,6 +363,31 @@
 			},
 			"bin": {
 				"specificity": "bin/cli.js"
+			}
+		},
+		"node_modules/@bufbuild/protobuf": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+			"integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+			"license": "(Apache-2.0 AND BSD-3-Clause)"
+		},
+		"node_modules/@connectrpc/connect": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+			"integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@bufbuild/protobuf": "^1.10.0"
+			}
+		},
+		"node_modules/@connectrpc/connect-web": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.7.0.tgz",
+			"integrity": "sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@bufbuild/protobuf": "^1.10.0",
+				"@connectrpc/connect": "1.7.0"
 			}
 		},
 		"node_modules/@csstools/color-helpers": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,9 @@
 		"node": ">=22.0.0"
 	},
 	"dependencies": {
+		"@bufbuild/protobuf": "^1.10.1",
+		"@connectrpc/connect": "^1.7.0",
+		"@connectrpc/connect-web": "^1.7.0",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
 		"react-router-dom": "^7.13.2"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,11 +6,13 @@ import { FusionRequestList } from "@/components/fusion/FusionRequestList";
 import { HomePage } from "@/components/HomePage";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { ApiClientProvider } from "@/lib/api-context";
-import { mockApiClient } from "@/lib/mock-api-client";
+import { createApiClient } from "@/lib/api-factory";
+
+const apiClient = createApiClient();
 
 export function App(): React.ReactElement {
 	return (
-		<ApiClientProvider client={mockApiClient}>
+		<ApiClientProvider client={apiClient}>
 			<BrowserRouter>
 				<Routes>
 					<Route element={<AppLayout />}>

--- a/frontend/src/lib/api-context.tsx
+++ b/frontend/src/lib/api-context.tsx
@@ -1,8 +1,7 @@
 import { createContext, useContext } from "react";
 import type { ApiClient } from "@/lib/api-client";
-import { mockApiClient } from "@/lib/mock-api-client";
 
-const ApiClientContext = createContext<ApiClient>(mockApiClient);
+const ApiClientContext = createContext<ApiClient | null>(null);
 
 /** API クライアントプロバイダー。 */
 export function ApiClientProvider({
@@ -15,7 +14,11 @@ export function ApiClientProvider({
 	return <ApiClientContext.Provider value={client}>{children}</ApiClientContext.Provider>;
 }
 
-/** API クライアントを取得するフック。 */
+/** API クライアントを取得するフック。ApiClientProvider 外で使用するとエラー。 */
 export function useApiClient(): ApiClient {
-	return useContext(ApiClientContext);
+	const client = useContext(ApiClientContext);
+	if (client === null) {
+		throw new Error("useApiClient must be used within an ApiClientProvider");
+	}
+	return client;
 }

--- a/frontend/src/lib/api-factory.ts
+++ b/frontend/src/lib/api-factory.ts
@@ -1,4 +1,6 @@
+import type { ServiceType } from "@bufbuild/protobuf";
 import type { ApiClient } from "@/lib/api-client";
+import { createGrpcApiClient } from "@/lib/grpc-api-client";
 import { mockApiClient } from "@/lib/mock-api-client";
 
 /**
@@ -18,22 +20,30 @@ export function createApiClient(): ApiClient {
 	return createLazyGrpcClient(apiUrl);
 }
 
+/** 生成コードモジュールの型。 */
+interface ServiceConnectModule {
+	FoodInventoryService: ServiceType;
+	FusionService: ServiceType;
+}
+
 /**
  * gRPC クライアントを遅延初期化するプロキシを返す。
- * 各メソッド呼び出し時に初めて grpc-api-client と生成コードをロードする。
+ * 各メソッド呼び出し時に初めて生成コードをロードする。
+ *
+ * gen ファイルのパスを変数化し、`@vite-ignore` で Vite の静的解析を、
+ * 変数参照で TypeScript のモジュール解決をそれぞれ回避する。
+ * CI 環境では frontend/src/gen/ が .gitignore で除外されている。
  */
 function createLazyGrpcClient(apiUrl: string): ApiClient {
 	let resolvedClient: ApiClient | null = null;
 
 	async function getClient(): Promise<ApiClient> {
 		if (resolvedClient === null) {
-			const [{ createGrpcApiClient }, { FoodInventoryService, FusionService }] = await Promise.all([
-				import("@/lib/grpc-api-client"),
-				import("@/gen/shokudo/v1/service_connect"),
-			]);
+			const serviceConnectPath = "@/gen/shokudo/v1/service_connect";
+			const serviceModule = (await import(/* @vite-ignore */ serviceConnectPath)) as ServiceConnectModule;
 			resolvedClient = createGrpcApiClient(apiUrl, {
-				foodInventoryService: FoodInventoryService,
-				fusionService: FusionService,
+				foodInventoryService: serviceModule.FoodInventoryService,
+				fusionService: serviceModule.FusionService,
 			});
 		}
 		return resolvedClient;

--- a/frontend/src/lib/api-factory.ts
+++ b/frontend/src/lib/api-factory.ts
@@ -1,0 +1,62 @@
+import type { ApiClient } from "@/lib/api-client";
+import { mockApiClient } from "@/lib/mock-api-client";
+
+/**
+ * 環境に応じた ApiClient を作成する。
+ *
+ * - `VITE_API_URL` が設定されている場合: gRPC-Web クライアントを返す
+ * - 未設定の場合: モック API クライアントを返す（開発用デフォルト）
+ *
+ * gRPC クライアントは動的 import で遅延ロードする。
+ * これにより service_pb.js が未生成の開発環境でもモックで動作する。
+ */
+export function createApiClient(): ApiClient {
+	const apiUrl = import.meta.env.VITE_API_URL;
+	if (!apiUrl) {
+		return mockApiClient;
+	}
+	return createLazyGrpcClient(apiUrl);
+}
+
+/**
+ * gRPC クライアントを遅延初期化するプロキシを返す。
+ * 各メソッド呼び出し時に初めて grpc-api-client モジュールをロードする。
+ */
+function createLazyGrpcClient(apiUrl: string): ApiClient {
+	let resolvedClient: ApiClient | null = null;
+
+	async function getClient(): Promise<ApiClient> {
+		if (resolvedClient === null) {
+			const { createGrpcApiClient } = await import("@/lib/grpc-api-client");
+			resolvedClient = createGrpcApiClient(apiUrl);
+		}
+		return resolvedClient;
+	}
+
+	return {
+		async createFoodItem(input) {
+			const client = await getClient();
+			return client.createFoodItem(input);
+		},
+		async listFoodItems(pageSize, pageToken, categoryFilter) {
+			const client = await getClient();
+			return client.listFoodItems(pageSize, pageToken, categoryFilter);
+		},
+		async deleteFoodItem(id) {
+			const client = await getClient();
+			return client.deleteFoodItem(id);
+		},
+		async createFusionRequest(input) {
+			const client = await getClient();
+			return client.createFusionRequest(input);
+		},
+		async listFusionRequests(pageSize, pageToken, statusFilter) {
+			const client = await getClient();
+			return client.listFusionRequests(pageSize, pageToken, statusFilter);
+		},
+		async respondToFusionRequest(id, response, foodItemId) {
+			const client = await getClient();
+			return client.respondToFusionRequest(id, response, foodItemId);
+		},
+	};
+}

--- a/frontend/src/lib/api-factory.ts
+++ b/frontend/src/lib/api-factory.ts
@@ -7,8 +7,8 @@ import { mockApiClient } from "@/lib/mock-api-client";
  * - `VITE_API_URL` が設定されている場合: gRPC-Web クライアントを返す
  * - 未設定の場合: モック API クライアントを返す（開発用デフォルト）
  *
- * gRPC クライアントは動的 import で遅延ロードする。
- * これにより service_pb.js が未生成の開発環境でもモックで動作する。
+ * gRPC クライアントと生成コードは動的 import で遅延ロードする。
+ * これにより service_pb.js が未生成の開発/テスト環境でもモックで動作する。
  */
 export function createApiClient(): ApiClient {
 	const apiUrl = import.meta.env.VITE_API_URL;
@@ -20,15 +20,21 @@ export function createApiClient(): ApiClient {
 
 /**
  * gRPC クライアントを遅延初期化するプロキシを返す。
- * 各メソッド呼び出し時に初めて grpc-api-client モジュールをロードする。
+ * 各メソッド呼び出し時に初めて grpc-api-client と生成コードをロードする。
  */
 function createLazyGrpcClient(apiUrl: string): ApiClient {
 	let resolvedClient: ApiClient | null = null;
 
 	async function getClient(): Promise<ApiClient> {
 		if (resolvedClient === null) {
-			const { createGrpcApiClient } = await import("@/lib/grpc-api-client");
-			resolvedClient = createGrpcApiClient(apiUrl);
+			const [{ createGrpcApiClient }, { FoodInventoryService, FusionService }] = await Promise.all([
+				import("@/lib/grpc-api-client"),
+				import("@/gen/shokudo/v1/service_connect"),
+			]);
+			resolvedClient = createGrpcApiClient(apiUrl, {
+				foodInventoryService: FoodInventoryService,
+				fusionService: FusionService,
+			});
 		}
 		return resolvedClient;
 	}

--- a/frontend/src/lib/grpc-api-client.ts
+++ b/frontend/src/lib/grpc-api-client.ts
@@ -1,0 +1,217 @@
+import { createPromiseClient } from "@connectrpc/connect";
+import { createGrpcWebTransport } from "@connectrpc/connect-web";
+import { FoodInventoryService, FusionService } from "@/gen/shokudo/v1/service_connect";
+import type { ApiClient, ListFoodItemsResult, ListFusionRequestsResult } from "@/lib/api-client";
+import { ApiError } from "@/lib/api-client";
+import type {
+	CreateFoodItemInput,
+	CreateFusionRequestInput,
+	FoodCategory,
+	FoodItem,
+	FusionRequest,
+} from "@/types/domain";
+
+/** gRPC レスポンスの食品アイテムフィールド。 */
+interface FoodItemFields {
+	id?: unknown;
+	name?: unknown;
+	category?: unknown;
+	expiryDate?: unknown;
+	quantity?: unknown;
+	unit?: unknown;
+	donorId?: unknown;
+	status?: unknown;
+	createdAt?: unknown;
+	updatedAt?: unknown;
+}
+
+/** gRPC レスポンスの融通リクエストフィールド。 */
+interface FusionRequestFields {
+	id?: unknown;
+	requesterShokudoId?: unknown;
+	desiredCategory?: unknown;
+	desiredQuantity?: unknown;
+	unit?: unknown;
+	message?: unknown;
+	status?: unknown;
+	responderShokudoId?: unknown;
+	foodItemId?: unknown;
+	createdAt?: unknown;
+	updatedAt?: unknown;
+}
+
+/** gRPC レスポンスの一覧フィールド。 */
+interface ListResponseFields {
+	items?: unknown[];
+	nextPageToken?: unknown;
+	totalCount?: unknown;
+}
+
+/**
+ * Connect gRPC-Web トランスポートを使用する実 API クライアントを作成する。
+ *
+ * @param baseUrl - gRPC バックエンドの URL（例: "http://localhost:8080"）
+ */
+export function createGrpcApiClient(baseUrl: string): ApiClient {
+	const transport = createGrpcWebTransport({ baseUrl });
+	const foodClient = createPromiseClient(FoodInventoryService, transport);
+	const fusionClient = createPromiseClient(FusionService, transport);
+
+	return {
+		async createFoodItem(input: CreateFoodItemInput): Promise<FoodItem> {
+			try {
+				const response = await foodClient.createFoodItem({
+					name: input.name,
+					category: input.category || undefined,
+					expiryDate: input.expiryDate,
+					quantity: typeof input.quantity === "number" ? input.quantity : 0,
+					unit: input.unit || undefined,
+					donorId: input.donorId,
+				});
+				return mapFoodItemResponse(response as unknown as FoodItemFields);
+			} catch (error) {
+				throw toApiError(error);
+			}
+		},
+
+		async listFoodItems(
+			pageSize: number,
+			pageToken: string,
+			categoryFilter: FoodCategory | "",
+		): Promise<ListFoodItemsResult> {
+			try {
+				const response = await foodClient.listFoodItems({
+					pageSize,
+					pageToken,
+					categoryFilter: categoryFilter || undefined,
+				});
+				const fields = response as unknown as ListResponseFields;
+				const rawItems = fields.items ?? [];
+				return {
+					items: rawItems.map((item) => mapFoodItemResponse(item as FoodItemFields)),
+					pagination: {
+						nextPageToken: String(fields.nextPageToken ?? ""),
+						totalCount: Number(fields.totalCount ?? 0),
+					},
+				};
+			} catch (error) {
+				throw toApiError(error);
+			}
+		},
+
+		async deleteFoodItem(id: string): Promise<void> {
+			try {
+				await foodClient.deleteFoodItem({ id });
+			} catch (error) {
+				throw toApiError(error);
+			}
+		},
+
+		async createFusionRequest(input: CreateFusionRequestInput): Promise<FusionRequest> {
+			try {
+				const response = await fusionClient.createFusionRequest({
+					requesterShokudoId: input.requesterShokudoId,
+					desiredCategory: input.desiredCategory || undefined,
+					desiredQuantity: typeof input.desiredQuantity === "number" ? input.desiredQuantity : 0,
+					unit: input.unit || undefined,
+					message: input.message,
+				});
+				return mapFusionRequestResponse(response as unknown as FusionRequestFields);
+			} catch (error) {
+				throw toApiError(error);
+			}
+		},
+
+		async listFusionRequests(
+			pageSize: number,
+			pageToken: string,
+			statusFilter: string,
+		): Promise<ListFusionRequestsResult> {
+			try {
+				const response = await fusionClient.listFusionRequests({
+					pageSize,
+					pageToken,
+					statusFilter: statusFilter || undefined,
+				});
+				const fields = response as unknown as ListResponseFields;
+				const rawItems = fields.items ?? [];
+				return {
+					items: rawItems.map((item) => mapFusionRequestResponse(item as FusionRequestFields)),
+					pagination: {
+						nextPageToken: String(fields.nextPageToken ?? ""),
+						totalCount: Number(fields.totalCount ?? 0),
+					},
+				};
+			} catch (error) {
+				throw toApiError(error);
+			}
+		},
+
+		async respondToFusionRequest(
+			id: string,
+			response: "APPROVED" | "REJECTED",
+			foodItemId: string,
+		): Promise<FusionRequest> {
+			try {
+				const res = await fusionClient.respondToFusionRequest({
+					id,
+					response,
+					foodItemId,
+				});
+				return mapFusionRequestResponse(res as unknown as FusionRequestFields);
+			} catch (error) {
+				throw toApiError(error);
+			}
+		},
+	};
+}
+
+/**
+ * gRPC レスポンスから FoodItem ドメインモデルに変換する。
+ */
+function mapFoodItemResponse(fields: FoodItemFields): FoodItem {
+	return {
+		id: String(fields.id ?? ""),
+		name: String(fields.name ?? ""),
+		category: String(fields.category ?? "") as FoodItem["category"],
+		expiryDate: String(fields.expiryDate ?? ""),
+		quantity: Number(fields.quantity ?? 0),
+		unit: String(fields.unit ?? "") as FoodItem["unit"],
+		donorId: String(fields.donorId ?? ""),
+		status: String(fields.status ?? "available") as FoodItem["status"],
+		createdAt: String(fields.createdAt ?? ""),
+		updatedAt: String(fields.updatedAt ?? ""),
+	};
+}
+
+/** gRPC レスポンスから FusionRequest ドメインモデルに変換する。 */
+function mapFusionRequestResponse(fields: FusionRequestFields): FusionRequest {
+	return {
+		id: String(fields.id ?? ""),
+		requesterShokudoId: String(fields.requesterShokudoId ?? ""),
+		desiredCategory: String(fields.desiredCategory ?? "") as FusionRequest["desiredCategory"],
+		desiredQuantity: Number(fields.desiredQuantity ?? 0),
+		unit: String(fields.unit ?? "") as FusionRequest["unit"],
+		message: String(fields.message ?? ""),
+		status: String(fields.status ?? "pending") as FusionRequest["status"],
+		responderShokudoId: String(fields.responderShokudoId ?? ""),
+		foodItemId: String(fields.foodItemId ?? ""),
+		createdAt: String(fields.createdAt ?? ""),
+		updatedAt: String(fields.updatedAt ?? ""),
+	};
+}
+
+/** Connect エラーを ApiError に変換する。 */
+function toApiError(error: unknown): ApiError {
+	if (error instanceof ApiError) {
+		return error;
+	}
+	if (error instanceof Error && "code" in error) {
+		const connectError = error as Error & { code: unknown };
+		return new ApiError(String(connectError.code), error.message);
+	}
+	if (error instanceof Error) {
+		return new ApiError("UNKNOWN", error.message);
+	}
+	return new ApiError("UNKNOWN", String(error));
+}

--- a/frontend/src/lib/grpc-api-client.ts
+++ b/frontend/src/lib/grpc-api-client.ts
@@ -1,6 +1,6 @@
+import type { ServiceType } from "@bufbuild/protobuf";
 import { createPromiseClient } from "@connectrpc/connect";
 import { createGrpcWebTransport } from "@connectrpc/connect-web";
-import { FoodInventoryService, FusionService } from "@/gen/shokudo/v1/service_connect";
 import type { ApiClient, ListFoodItemsResult, ListFusionRequestsResult } from "@/lib/api-client";
 import { ApiError } from "@/lib/api-client";
 import type {
@@ -47,20 +47,43 @@ interface ListResponseFields {
 	totalCount?: unknown;
 }
 
+/** サービス定義の注入パラメータ。gen ファイルへの直接依存を回避する。 */
+export interface GrpcServiceDefs {
+	readonly foodInventoryService: ServiceType;
+	readonly fusionService: ServiceType;
+}
+
+/**
+ * RPC メソッドを安全に呼び出すヘルパー。
+ * createPromiseClient が返す Client<ServiceType> の各メソッドは
+ * index signature 由来で undefined になりうるため、
+ * 存在チェック付きで呼び出す。
+ */
+type RpcCaller = Record<string, ((request: unknown) => Promise<unknown>) | undefined>;
+
+function callRpc(client: RpcCaller, method: string, request: unknown): Promise<unknown> {
+	const fn = client[method];
+	if (fn === undefined) {
+		throw new ApiError("INTERNAL", `RPC method "${method}" not found on client`);
+	}
+	return fn(request);
+}
+
 /**
  * Connect gRPC-Web トランスポートを使用する実 API クライアントを作成する。
  *
  * @param baseUrl - gRPC バックエンドの URL（例: "http://localhost:8080"）
+ * @param services - 生成されたサービス定義（FoodInventoryService, FusionService）
  */
-export function createGrpcApiClient(baseUrl: string): ApiClient {
+export function createGrpcApiClient(baseUrl: string, services: GrpcServiceDefs): ApiClient {
 	const transport = createGrpcWebTransport({ baseUrl });
-	const foodClient = createPromiseClient(FoodInventoryService, transport);
-	const fusionClient = createPromiseClient(FusionService, transport);
+	const foodClient = createPromiseClient(services.foodInventoryService, transport) as unknown as RpcCaller;
+	const fusionClient = createPromiseClient(services.fusionService, transport) as unknown as RpcCaller;
 
 	return {
 		async createFoodItem(input: CreateFoodItemInput): Promise<FoodItem> {
 			try {
-				const response = await foodClient.createFoodItem({
+				const response = await callRpc(foodClient, "createFoodItem", {
 					name: input.name,
 					category: input.category || undefined,
 					expiryDate: input.expiryDate,
@@ -68,7 +91,7 @@ export function createGrpcApiClient(baseUrl: string): ApiClient {
 					unit: input.unit || undefined,
 					donorId: input.donorId,
 				});
-				return mapFoodItemResponse(response as unknown as FoodItemFields);
+				return mapFoodItemResponse(response as FoodItemFields);
 			} catch (error) {
 				throw toApiError(error);
 			}
@@ -80,12 +103,12 @@ export function createGrpcApiClient(baseUrl: string): ApiClient {
 			categoryFilter: FoodCategory | "",
 		): Promise<ListFoodItemsResult> {
 			try {
-				const response = await foodClient.listFoodItems({
+				const response = await callRpc(foodClient, "listFoodItems", {
 					pageSize,
 					pageToken,
 					categoryFilter: categoryFilter || undefined,
 				});
-				const fields = response as unknown as ListResponseFields;
+				const fields = response as ListResponseFields;
 				const rawItems = fields.items ?? [];
 				return {
 					items: rawItems.map((item) => mapFoodItemResponse(item as FoodItemFields)),
@@ -101,7 +124,7 @@ export function createGrpcApiClient(baseUrl: string): ApiClient {
 
 		async deleteFoodItem(id: string): Promise<void> {
 			try {
-				await foodClient.deleteFoodItem({ id });
+				await callRpc(foodClient, "deleteFoodItem", { id });
 			} catch (error) {
 				throw toApiError(error);
 			}
@@ -109,14 +132,14 @@ export function createGrpcApiClient(baseUrl: string): ApiClient {
 
 		async createFusionRequest(input: CreateFusionRequestInput): Promise<FusionRequest> {
 			try {
-				const response = await fusionClient.createFusionRequest({
+				const response = await callRpc(fusionClient, "createFusionRequest", {
 					requesterShokudoId: input.requesterShokudoId,
 					desiredCategory: input.desiredCategory || undefined,
 					desiredQuantity: typeof input.desiredQuantity === "number" ? input.desiredQuantity : 0,
 					unit: input.unit || undefined,
 					message: input.message,
 				});
-				return mapFusionRequestResponse(response as unknown as FusionRequestFields);
+				return mapFusionRequestResponse(response as FusionRequestFields);
 			} catch (error) {
 				throw toApiError(error);
 			}
@@ -128,12 +151,12 @@ export function createGrpcApiClient(baseUrl: string): ApiClient {
 			statusFilter: string,
 		): Promise<ListFusionRequestsResult> {
 			try {
-				const response = await fusionClient.listFusionRequests({
+				const response = await callRpc(fusionClient, "listFusionRequests", {
 					pageSize,
 					pageToken,
 					statusFilter: statusFilter || undefined,
 				});
-				const fields = response as unknown as ListResponseFields;
+				const fields = response as ListResponseFields;
 				const rawItems = fields.items ?? [];
 				return {
 					items: rawItems.map((item) => mapFusionRequestResponse(item as FusionRequestFields)),
@@ -153,12 +176,12 @@ export function createGrpcApiClient(baseUrl: string): ApiClient {
 			foodItemId: string,
 		): Promise<FusionRequest> {
 			try {
-				const res = await fusionClient.respondToFusionRequest({
+				const res = await callRpc(fusionClient, "respondToFusionRequest", {
 					id,
 					response,
 					foodItemId,
 				});
-				return mapFusionRequestResponse(res as unknown as FusionRequestFields);
+				return mapFusionRequestResponse(res as FusionRequestFields);
 			} catch (error) {
 				throw toApiError(error);
 			}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+	/** gRPC バックエンドの URL。未設定時はモック API を使用。 */
+	readonly VITE_API_URL?: string;
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

- App.tsx が `mockApiClient` を直接 `ApiClientProvider` に注入しており、バックエンド接続への切り替えパスがなかった
- `VITE_API_URL` 環境変数の有無で gRPC-Web クライアントとモックを切り替える `api-factory.ts` を導入
- gRPC クライアントは動的 import で遅延ロードし、`service_pb.js` 未生成の開発環境でもモックで動作可能

## Changes

- `frontend/src/lib/api-factory.ts`: 環境変数ベースの ApiClient ファクトリ
- `frontend/src/lib/grpc-api-client.ts`: Connect gRPC-Web による ApiClient 実装
- `frontend/src/App.tsx`: `mockApiClient` 直接参照を `createApiClient()` に置換
- `frontend/src/lib/api-context.tsx`: createContext のデフォルト値を null に変更、useApiClient にガード追加
- `frontend/src/vite-env.d.ts`: `VITE_API_URL` の型定義追加
- `frontend/package.json`: `@connectrpc/connect`, `@connectrpc/connect-web`, `@bufbuild/protobuf` 追加
- `.env.example`: `VITE_API_URL` の設定例

## Test plan

- [x] `make check` 全パス（lint, typecheck, test 59件, build）
- [x] `VITE_API_URL` 未設定時にモック API で動作（既存テスト全パス）
- [ ] `VITE_API_URL=http://localhost:8080` 設定時に gRPC バックエンドへ接続