### PR TITLE
fix: P1/P2 proto contract alignment and error hardening

### DIFF
--- a/backend/gen/shokudo/v1/service.pb.go
+++ b/backend/gen/shokudo/v1/service.pb.go
@@ -836,98 +836,6 @@ func (x *RespondToFusionRequestResponse) GetFusionRequest() *FusionRequest {
 	return nil
 }
 
-// CompleteFusionRequest のリクエスト。
-type CompleteFusionRequestRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// 融通リクエストのID。必須。
-	FusionRequestId string `protobuf:"bytes,1,opt,name=fusion_request_id,json=fusionRequestId,proto3" json:"fusion_request_id,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
-}
-
-func (x *CompleteFusionRequestRequest) Reset() {
-	*x = CompleteFusionRequestRequest{}
-	mi := &file_shokudo_v1_service_proto_msgTypes[14]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *CompleteFusionRequestRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*CompleteFusionRequestRequest) ProtoMessage() {}
-
-func (x *CompleteFusionRequestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_shokudo_v1_service_proto_msgTypes[14]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use CompleteFusionRequestRequest.ProtoReflect.Descriptor instead.
-func (*CompleteFusionRequestRequest) Descriptor() ([]byte, []int) {
-	return file_shokudo_v1_service_proto_rawDescGZIP(), []int{14}
-}
-
-func (x *CompleteFusionRequestRequest) GetFusionRequestId() string {
-	if x != nil {
-		return x.FusionRequestId
-	}
-	return ""
-}
-
-// CompleteFusionRequest のレスポンス。
-type CompleteFusionRequestResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// 更新された融通リクエスト。
-	FusionRequest *FusionRequest `protobuf:"bytes,1,opt,name=fusion_request,json=fusionRequest,proto3" json:"fusion_request,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *CompleteFusionRequestResponse) Reset() {
-	*x = CompleteFusionRequestResponse{}
-	mi := &file_shokudo_v1_service_proto_msgTypes[15]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *CompleteFusionRequestResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*CompleteFusionRequestResponse) ProtoMessage() {}
-
-func (x *CompleteFusionRequestResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_shokudo_v1_service_proto_msgTypes[15]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use CompleteFusionRequestResponse.ProtoReflect.Descriptor instead.
-func (*CompleteFusionRequestResponse) Descriptor() ([]byte, []int) {
-	return file_shokudo_v1_service_proto_rawDescGZIP(), []int{15}
-}
-
-func (x *CompleteFusionRequestResponse) GetFusionRequest() *FusionRequest {
-	if x != nil {
-		return x.FusionRequest
-	}
-	return nil
-}
-
 // 食品アイテムのドメインモデル。
 type FoodItem struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -957,7 +865,7 @@ type FoodItem struct {
 
 func (x *FoodItem) Reset() {
 	*x = FoodItem{}
-	mi := &file_shokudo_v1_service_proto_msgTypes[16]
+	mi := &file_shokudo_v1_service_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -969,7 +877,7 @@ func (x *FoodItem) String() string {
 func (*FoodItem) ProtoMessage() {}
 
 func (x *FoodItem) ProtoReflect() protoreflect.Message {
-	mi := &file_shokudo_v1_service_proto_msgTypes[16]
+	mi := &file_shokudo_v1_service_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -982,7 +890,7 @@ func (x *FoodItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FoodItem.ProtoReflect.Descriptor instead.
 func (*FoodItem) Descriptor() ([]byte, []int) {
-	return file_shokudo_v1_service_proto_rawDescGZIP(), []int{16}
+	return file_shokudo_v1_service_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *FoodItem) GetId() string {
@@ -1086,7 +994,7 @@ type FusionRequest struct {
 
 func (x *FusionRequest) Reset() {
 	*x = FusionRequest{}
-	mi := &file_shokudo_v1_service_proto_msgTypes[17]
+	mi := &file_shokudo_v1_service_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1098,7 +1006,7 @@ func (x *FusionRequest) String() string {
 func (*FusionRequest) ProtoMessage() {}
 
 func (x *FusionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_shokudo_v1_service_proto_msgTypes[17]
+	mi := &file_shokudo_v1_service_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1111,7 +1019,7 @@ func (x *FusionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FusionRequest.ProtoReflect.Descriptor instead.
 func (*FusionRequest) Descriptor() ([]byte, []int) {
-	return file_shokudo_v1_service_proto_rawDescGZIP(), []int{17}
+	return file_shokudo_v1_service_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *FusionRequest) GetId() string {
@@ -1249,10 +1157,6 @@ const file_shokudo_v1_service_proto_rawDesc = "" +
 	"\ffood_item_id\x18\x03 \x01(\tR\n" +
 	"foodItemId\"b\n" +
 	"\x1eRespondToFusionRequestResponse\x12@\n" +
-	"\x0efusion_request\x18\x01 \x01(\v2\x19.shokudo.v1.FusionRequestR\rfusionRequest\"J\n" +
-	"\x1cCompleteFusionRequestRequest\x12*\n" +
-	"\x11fusion_request_id\x18\x01 \x01(\tR\x0ffusionRequestId\"a\n" +
-	"\x1dCompleteFusionRequestResponse\x12@\n" +
 	"\x0efusion_request\x18\x01 \x01(\v2\x19.shokudo.v1.FusionRequestR\rfusionRequest\"\x8c\x02\n" +
 	"\bFoodItem\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
@@ -1289,12 +1193,11 @@ const file_shokudo_v1_service_proto_rawDesc = "" +
 	"\x0eCreateFoodItem\x12!.shokudo.v1.CreateFoodItemRequest\x1a\".shokudo.v1.CreateFoodItemResponse\x12N\n" +
 	"\vGetFoodItem\x12\x1e.shokudo.v1.GetFoodItemRequest\x1a\x1f.shokudo.v1.GetFoodItemResponse\x12T\n" +
 	"\rListFoodItems\x12 .shokudo.v1.ListFoodItemsRequest\x1a!.shokudo.v1.ListFoodItemsResponse\x12W\n" +
-	"\x0eDeleteFoodItem\x12!.shokudo.v1.DeleteFoodItemRequest\x1a\".shokudo.v1.DeleteFoodItemResponse2\xbb\x03\n" +
+	"\x0eDeleteFoodItem\x12!.shokudo.v1.DeleteFoodItemRequest\x1a\".shokudo.v1.DeleteFoodItemResponse2\xcd\x02\n" +
 	"\rFusionService\x12f\n" +
 	"\x13CreateFusionRequest\x12&.shokudo.v1.CreateFusionRequestRequest\x1a'.shokudo.v1.CreateFusionRequestResponse\x12c\n" +
 	"\x12ListFusionRequests\x12%.shokudo.v1.ListFusionRequestsRequest\x1a&.shokudo.v1.ListFusionRequestsResponse\x12o\n" +
-	"\x16RespondToFusionRequest\x12).shokudo.v1.RespondToFusionRequestRequest\x1a*.shokudo.v1.RespondToFusionRequestResponse\x12l\n" +
-	"\x15CompleteFusionRequest\x12(.shokudo.v1.CompleteFusionRequestRequest\x1a).shokudo.v1.CompleteFusionRequestResponseB\xab\x01\n" +
+	"\x16RespondToFusionRequest\x12).shokudo.v1.RespondToFusionRequestRequest\x1a*.shokudo.v1.RespondToFusionRequestResponseB\xab\x01\n" +
 	"\x0ecom.shokudo.v1B\fServiceProtoP\x01ZBgithub.com/akaitigo/shokudo-nexus/backend/gen/shokudo/v1;shokudov1\xa2\x02\x03SXX\xaa\x02\n" +
 	"Shokudo.V1\xca\x02\n" +
 	"Shokudo\\V1\xe2\x02\x16Shokudo\\V1\\GPBMetadata\xea\x02\vShokudo::V1b\x06proto3"
@@ -1311,7 +1214,7 @@ func file_shokudo_v1_service_proto_rawDescGZIP() []byte {
 	return file_shokudo_v1_service_proto_rawDescData
 }
 
-var file_shokudo_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_shokudo_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_shokudo_v1_service_proto_goTypes = []any{
 	(*CreateFoodItemRequest)(nil),          // 0: shokudo.v1.CreateFoodItemRequest
 	(*CreateFoodItemResponse)(nil),         // 1: shokudo.v1.CreateFoodItemResponse
@@ -1327,40 +1230,35 @@ var file_shokudo_v1_service_proto_goTypes = []any{
 	(*ListFusionRequestsResponse)(nil),     // 11: shokudo.v1.ListFusionRequestsResponse
 	(*RespondToFusionRequestRequest)(nil),  // 12: shokudo.v1.RespondToFusionRequestRequest
 	(*RespondToFusionRequestResponse)(nil), // 13: shokudo.v1.RespondToFusionRequestResponse
-	(*CompleteFusionRequestRequest)(nil),   // 14: shokudo.v1.CompleteFusionRequestRequest
-	(*CompleteFusionRequestResponse)(nil),  // 15: shokudo.v1.CompleteFusionRequestResponse
-	(*FoodItem)(nil),                       // 16: shokudo.v1.FoodItem
-	(*FusionRequest)(nil),                  // 17: shokudo.v1.FusionRequest
+	(*FoodItem)(nil),                       // 14: shokudo.v1.FoodItem
+	(*FusionRequest)(nil),                  // 15: shokudo.v1.FusionRequest
 }
 var file_shokudo_v1_service_proto_depIdxs = []int32{
-	16, // 0: shokudo.v1.CreateFoodItemResponse.food_item:type_name -> shokudo.v1.FoodItem
-	16, // 1: shokudo.v1.GetFoodItemResponse.food_item:type_name -> shokudo.v1.FoodItem
-	16, // 2: shokudo.v1.ListFoodItemsResponse.food_items:type_name -> shokudo.v1.FoodItem
-	17, // 3: shokudo.v1.CreateFusionRequestResponse.fusion_request:type_name -> shokudo.v1.FusionRequest
-	17, // 4: shokudo.v1.ListFusionRequestsResponse.fusion_requests:type_name -> shokudo.v1.FusionRequest
-	17, // 5: shokudo.v1.RespondToFusionRequestResponse.fusion_request:type_name -> shokudo.v1.FusionRequest
-	17, // 6: shokudo.v1.CompleteFusionRequestResponse.fusion_request:type_name -> shokudo.v1.FusionRequest
-	0,  // 7: shokudo.v1.FoodInventoryService.CreateFoodItem:input_type -> shokudo.v1.CreateFoodItemRequest
-	2,  // 8: shokudo.v1.FoodInventoryService.GetFoodItem:input_type -> shokudo.v1.GetFoodItemRequest
-	4,  // 9: shokudo.v1.FoodInventoryService.ListFoodItems:input_type -> shokudo.v1.ListFoodItemsRequest
-	6,  // 10: shokudo.v1.FoodInventoryService.DeleteFoodItem:input_type -> shokudo.v1.DeleteFoodItemRequest
-	8,  // 11: shokudo.v1.FusionService.CreateFusionRequest:input_type -> shokudo.v1.CreateFusionRequestRequest
-	10, // 12: shokudo.v1.FusionService.ListFusionRequests:input_type -> shokudo.v1.ListFusionRequestsRequest
-	12, // 13: shokudo.v1.FusionService.RespondToFusionRequest:input_type -> shokudo.v1.RespondToFusionRequestRequest
-	14, // 14: shokudo.v1.FusionService.CompleteFusionRequest:input_type -> shokudo.v1.CompleteFusionRequestRequest
-	1,  // 15: shokudo.v1.FoodInventoryService.CreateFoodItem:output_type -> shokudo.v1.CreateFoodItemResponse
-	3,  // 16: shokudo.v1.FoodInventoryService.GetFoodItem:output_type -> shokudo.v1.GetFoodItemResponse
-	5,  // 17: shokudo.v1.FoodInventoryService.ListFoodItems:output_type -> shokudo.v1.ListFoodItemsResponse
-	7,  // 18: shokudo.v1.FoodInventoryService.DeleteFoodItem:output_type -> shokudo.v1.DeleteFoodItemResponse
-	9,  // 19: shokudo.v1.FusionService.CreateFusionRequest:output_type -> shokudo.v1.CreateFusionRequestResponse
-	11, // 20: shokudo.v1.FusionService.ListFusionRequests:output_type -> shokudo.v1.ListFusionRequestsResponse
-	13, // 21: shokudo.v1.FusionService.RespondToFusionRequest:output_type -> shokudo.v1.RespondToFusionRequestResponse
-	15, // 22: shokudo.v1.FusionService.CompleteFusionRequest:output_type -> shokudo.v1.CompleteFusionRequestResponse
-	15, // [15:23] is the sub-list for method output_type
-	7,  // [7:15] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	14, // 0: shokudo.v1.CreateFoodItemResponse.food_item:type_name -> shokudo.v1.FoodItem
+	14, // 1: shokudo.v1.GetFoodItemResponse.food_item:type_name -> shokudo.v1.FoodItem
+	14, // 2: shokudo.v1.ListFoodItemsResponse.food_items:type_name -> shokudo.v1.FoodItem
+	15, // 3: shokudo.v1.CreateFusionRequestResponse.fusion_request:type_name -> shokudo.v1.FusionRequest
+	15, // 4: shokudo.v1.ListFusionRequestsResponse.fusion_requests:type_name -> shokudo.v1.FusionRequest
+	15, // 5: shokudo.v1.RespondToFusionRequestResponse.fusion_request:type_name -> shokudo.v1.FusionRequest
+	0,  // 6: shokudo.v1.FoodInventoryService.CreateFoodItem:input_type -> shokudo.v1.CreateFoodItemRequest
+	2,  // 7: shokudo.v1.FoodInventoryService.GetFoodItem:input_type -> shokudo.v1.GetFoodItemRequest
+	4,  // 8: shokudo.v1.FoodInventoryService.ListFoodItems:input_type -> shokudo.v1.ListFoodItemsRequest
+	6,  // 9: shokudo.v1.FoodInventoryService.DeleteFoodItem:input_type -> shokudo.v1.DeleteFoodItemRequest
+	8,  // 10: shokudo.v1.FusionService.CreateFusionRequest:input_type -> shokudo.v1.CreateFusionRequestRequest
+	10, // 11: shokudo.v1.FusionService.ListFusionRequests:input_type -> shokudo.v1.ListFusionRequestsRequest
+	12, // 12: shokudo.v1.FusionService.RespondToFusionRequest:input_type -> shokudo.v1.RespondToFusionRequestRequest
+	1,  // 13: shokudo.v1.FoodInventoryService.CreateFoodItem:output_type -> shokudo.v1.CreateFoodItemResponse
+	3,  // 14: shokudo.v1.FoodInventoryService.GetFoodItem:output_type -> shokudo.v1.GetFoodItemResponse
+	5,  // 15: shokudo.v1.FoodInventoryService.ListFoodItems:output_type -> shokudo.v1.ListFoodItemsResponse
+	7,  // 16: shokudo.v1.FoodInventoryService.DeleteFoodItem:output_type -> shokudo.v1.DeleteFoodItemResponse
+	9,  // 17: shokudo.v1.FusionService.CreateFusionRequest:output_type -> shokudo.v1.CreateFusionRequestResponse
+	11, // 18: shokudo.v1.FusionService.ListFusionRequests:output_type -> shokudo.v1.ListFusionRequestsResponse
+	13, // 19: shokudo.v1.FusionService.RespondToFusionRequest:output_type -> shokudo.v1.RespondToFusionRequestResponse
+	13, // [13:20] is the sub-list for method output_type
+	6,  // [6:13] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_shokudo_v1_service_proto_init() }
@@ -1374,7 +1272,7 @@ func file_shokudo_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_shokudo_v1_service_proto_rawDesc), len(file_shokudo_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   18,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/backend/gen/shokudo/v1/service_grpc.pb.go
+++ b/backend/gen/shokudo/v1/service_grpc.pb.go
@@ -259,7 +259,6 @@ const (
 	FusionService_CreateFusionRequest_FullMethodName    = "/shokudo.v1.FusionService/CreateFusionRequest"
 	FusionService_ListFusionRequests_FullMethodName     = "/shokudo.v1.FusionService/ListFusionRequests"
 	FusionService_RespondToFusionRequest_FullMethodName = "/shokudo.v1.FusionService/RespondToFusionRequest"
-	FusionService_CompleteFusionRequest_FullMethodName  = "/shokudo.v1.FusionService/CompleteFusionRequest"
 )
 
 // FusionServiceClient is the client API for FusionService service.
@@ -274,8 +273,6 @@ type FusionServiceClient interface {
 	ListFusionRequests(ctx context.Context, in *ListFusionRequestsRequest, opts ...grpc.CallOption) (*ListFusionRequestsResponse, error)
 	// 融通リクエストに応答する（承認/拒否）。
 	RespondToFusionRequest(ctx context.Context, in *RespondToFusionRequestRequest, opts ...grpc.CallOption) (*RespondToFusionRequestResponse, error)
-	// 融通リクエストを完了する（承認済み→完了への遷移）。
-	CompleteFusionRequest(ctx context.Context, in *CompleteFusionRequestRequest, opts ...grpc.CallOption) (*CompleteFusionRequestResponse, error)
 }
 
 type fusionServiceClient struct {
@@ -316,16 +313,6 @@ func (c *fusionServiceClient) RespondToFusionRequest(ctx context.Context, in *Re
 	return out, nil
 }
 
-func (c *fusionServiceClient) CompleteFusionRequest(ctx context.Context, in *CompleteFusionRequestRequest, opts ...grpc.CallOption) (*CompleteFusionRequestResponse, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(CompleteFusionRequestResponse)
-	err := c.cc.Invoke(ctx, FusionService_CompleteFusionRequest_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 // FusionServiceServer is the server API for FusionService service.
 // All implementations must embed UnimplementedFusionServiceServer
 // for forward compatibility.
@@ -338,8 +325,6 @@ type FusionServiceServer interface {
 	ListFusionRequests(context.Context, *ListFusionRequestsRequest) (*ListFusionRequestsResponse, error)
 	// 融通リクエストに応答する（承認/拒否）。
 	RespondToFusionRequest(context.Context, *RespondToFusionRequestRequest) (*RespondToFusionRequestResponse, error)
-	// 融通リクエストを完了する（承認済み→完了への遷移）。
-	CompleteFusionRequest(context.Context, *CompleteFusionRequestRequest) (*CompleteFusionRequestResponse, error)
 	mustEmbedUnimplementedFusionServiceServer()
 }
 
@@ -358,9 +343,6 @@ func (UnimplementedFusionServiceServer) ListFusionRequests(context.Context, *Lis
 }
 func (UnimplementedFusionServiceServer) RespondToFusionRequest(context.Context, *RespondToFusionRequestRequest) (*RespondToFusionRequestResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RespondToFusionRequest not implemented")
-}
-func (UnimplementedFusionServiceServer) CompleteFusionRequest(context.Context, *CompleteFusionRequestRequest) (*CompleteFusionRequestResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method CompleteFusionRequest not implemented")
 }
 func (UnimplementedFusionServiceServer) mustEmbedUnimplementedFusionServiceServer() {}
 func (UnimplementedFusionServiceServer) testEmbeddedByValue()                       {}
@@ -437,24 +419,6 @@ func _FusionService_RespondToFusionRequest_Handler(srv interface{}, ctx context.
 	return interceptor(ctx, in, info, handler)
 }
 
-func _FusionService_CompleteFusionRequest_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CompleteFusionRequestRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(FusionServiceServer).CompleteFusionRequest(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: FusionService_CompleteFusionRequest_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(FusionServiceServer).CompleteFusionRequest(ctx, req.(*CompleteFusionRequestRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 // FusionService_ServiceDesc is the grpc.ServiceDesc for FusionService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -473,10 +437,6 @@ var FusionService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RespondToFusionRequest",
 			Handler:    _FusionService_RespondToFusionRequest_Handler,
-		},
-		{
-			MethodName: "CompleteFusionRequest",
-			Handler:    _FusionService_CompleteFusionRequest_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/backend/internal/domain/category.go
+++ b/backend/internal/domain/category.go
@@ -22,6 +22,7 @@ var ValidUnits = map[string]bool{
 	"パック": true,
 	"本":   true,
 	"袋":   true,
+	"箱":   true,
 }
 
 // IsValidUnit は単位が定義済みかどうかを判定する。

--- a/backend/internal/domain/category_test.go
+++ b/backend/internal/domain/category_test.go
@@ -38,6 +38,7 @@ func TestIsValidUnit(t *testing.T) {
 		{"パック", true},
 		{"本", true},
 		{"袋", true},
+		{"箱", true},
 		{"リットル", false},
 		{"", false},
 		{"g", false},

--- a/backend/internal/service/food_inventory.go
+++ b/backend/internal/service/food_inventory.go
@@ -3,6 +3,7 @@ package service
 
 import (
 	"context"
+	"log"
 	"time"
 	"unicode/utf8"
 
@@ -64,7 +65,8 @@ func (s *FoodInventoryService) CreateFoodItem(ctx context.Context, req *pb.Creat
 
 	created, err := s.repo.Create(ctx, item)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to create food item: %v", err)
+		log.Printf("ERROR: failed to create food item: %v", err)
+		return nil, status.Error(codes.Internal, "failed to create food item")
 	}
 
 	return &pb.CreateFoodItemResponse{
@@ -89,7 +91,8 @@ func (s *FoodInventoryService) GetFoodItem(ctx context.Context, req *pb.GetFoodI
 		item.Status = domain.FoodItemStatusExpired
 		item.UpdatedAt = now
 		if updateErr := s.repo.Update(ctx, item); updateErr != nil {
-			return nil, status.Errorf(codes.Internal, "failed to update expired status: %v", updateErr)
+			log.Printf("ERROR: failed to update expired status for item %s: %v", item.ID, updateErr)
+			return nil, status.Error(codes.Internal, "failed to update food item status")
 		}
 	}
 

--- a/backend/internal/service/fusion.go
+++ b/backend/internal/service/fusion.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"log"
 	"sync"
 	"time"
 
@@ -52,7 +53,8 @@ func (s *FusionService) CreateFusionRequest(ctx context.Context, req *pb.CreateF
 
 	created, err := s.fusionRepo.Create(ctx, fusionReq)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to create fusion request: %v", err)
+		log.Printf("ERROR: failed to create fusion request: %v", err)
+		return nil, status.Error(codes.Internal, "failed to create fusion request")
 	}
 
 	return &pb.CreateFusionRequestResponse{
@@ -169,7 +171,8 @@ func (s *FusionService) RespondToFusionRequest(ctx context.Context, req *pb.Resp
 		foodItem.Status = domain.FoodItemStatusReserved
 		foodItem.UpdatedAt = now
 		if updateErr := s.foodItemRepo.Update(ctx, foodItem); updateErr != nil {
-			return nil, status.Errorf(codes.Internal, "failed to update food item status: %v", updateErr)
+			log.Printf("ERROR: failed to update food item status for %s: %v", foodItem.ID, updateErr)
+			return nil, status.Error(codes.Internal, "failed to update food item status")
 		}
 
 		fusionReq.Status = domain.FusionRequestStatusApproved
@@ -180,13 +183,14 @@ func (s *FusionService) RespondToFusionRequest(ctx context.Context, req *pb.Resp
 	}
 
 	if updateErr := s.fusionRepo.Update(ctx, fusionReq); updateErr != nil {
+		log.Printf("ERROR: failed to update fusion request %s: %v", req.GetFusionRequestId(), updateErr)
 		// Rollback: food item が reserved に更新済みの場合、available に戻す
 		if req.GetResponse() == "APPROVED" && foodItem != nil {
 			foodItem.Status = domain.FoodItemStatusAvailable
 			foodItem.UpdatedAt = now
 			_ = s.foodItemRepo.Update(ctx, foodItem) // best-effort rollback
 		}
-		return nil, status.Errorf(codes.Internal, "failed to update fusion request: %v", updateErr)
+		return nil, status.Error(codes.Internal, "failed to update fusion request")
 	}
 
 	return &pb.RespondToFusionRequestResponse{

--- a/frontend/src/components/fusion/FusionRequestList.tsx
+++ b/frontend/src/components/fusion/FusionRequestList.tsx
@@ -52,13 +52,22 @@ export function FusionRequestList(): React.ReactElement {
 
 	const handleRespond = useCallback(
 		async (request: FusionRequest, response: "APPROVED" | "REJECTED") => {
+			let foodItemId = "";
+			if (response === "APPROVED") {
+				const input = window.prompt("提供する食品アイテムIDを入力してください:");
+				if (input === null) return;
+				foodItemId = input.trim();
+				if (!foodItemId) {
+					return;
+				}
+			}
 			const label = response === "APPROVED" ? "承認" : "拒否";
 			if (!window.confirm(`このリクエストを${label}しますか？`)) {
 				return;
 			}
 			setResponding(request.id);
 			try {
-				await respondToRequest(request.id, response);
+				await respondToRequest(request.id, response, foodItemId);
 			} catch {
 				// エラーはフックで処理済み
 			} finally {

--- a/frontend/src/lib/grpc-api-client.ts
+++ b/frontend/src/lib/grpc-api-client.ts
@@ -40,9 +40,25 @@ interface FusionRequestFields {
 	updatedAt?: unknown;
 }
 
-/** gRPC レスポンスの一覧フィールド。 */
-interface ListResponseFields {
-	items?: unknown[];
+/** gRPC レスポンスの単一リソースラッパー。 */
+interface FoodItemResponseWrapper {
+	foodItem?: FoodItemFields;
+}
+
+interface FusionRequestResponseWrapper {
+	fusionRequest?: FusionRequestFields;
+}
+
+/** gRPC レスポンスの食品一覧フィールド。 */
+interface ListFoodItemsResponseFields {
+	foodItems?: unknown[];
+	nextPageToken?: unknown;
+	totalCount?: unknown;
+}
+
+/** gRPC レスポンスの融通リクエスト一覧フィールド。 */
+interface ListFusionRequestsResponseFields {
+	fusionRequests?: unknown[];
 	nextPageToken?: unknown;
 	totalCount?: unknown;
 }
@@ -83,15 +99,17 @@ export function createGrpcApiClient(baseUrl: string, services: GrpcServiceDefs):
 	return {
 		async createFoodItem(input: CreateFoodItemInput): Promise<FoodItem> {
 			try {
+				const expiryDateRfc3339 = toRfc3339Date(input.expiryDate);
 				const response = await callRpc(foodClient, "createFoodItem", {
 					name: input.name,
 					category: input.category || undefined,
-					expiryDate: input.expiryDate,
+					expiryDate: expiryDateRfc3339,
 					quantity: typeof input.quantity === "number" ? input.quantity : 0,
 					unit: input.unit || undefined,
 					donorId: input.donorId,
 				});
-				return mapFoodItemResponse(response as FoodItemFields);
+				const wrapper = response as FoodItemResponseWrapper;
+				return mapFoodItemResponse((wrapper.foodItem ?? response) as FoodItemFields);
 			} catch (error) {
 				throw toApiError(error);
 			}
@@ -108,8 +126,8 @@ export function createGrpcApiClient(baseUrl: string, services: GrpcServiceDefs):
 					pageToken,
 					categoryFilter: categoryFilter || undefined,
 				});
-				const fields = response as ListResponseFields;
-				const rawItems = fields.items ?? [];
+				const fields = response as ListFoodItemsResponseFields;
+				const rawItems = fields.foodItems ?? [];
 				return {
 					items: rawItems.map((item) => mapFoodItemResponse(item as FoodItemFields)),
 					pagination: {
@@ -139,7 +157,8 @@ export function createGrpcApiClient(baseUrl: string, services: GrpcServiceDefs):
 					unit: input.unit || undefined,
 					message: input.message,
 				});
-				return mapFusionRequestResponse(response as FusionRequestFields);
+				const wrapper = response as FusionRequestResponseWrapper;
+				return mapFusionRequestResponse((wrapper.fusionRequest ?? response) as FusionRequestFields);
 			} catch (error) {
 				throw toApiError(error);
 			}
@@ -156,8 +175,8 @@ export function createGrpcApiClient(baseUrl: string, services: GrpcServiceDefs):
 					pageToken,
 					statusFilter: statusFilter || undefined,
 				});
-				const fields = response as ListResponseFields;
-				const rawItems = fields.items ?? [];
+				const fields = response as ListFusionRequestsResponseFields;
+				const rawItems = fields.fusionRequests ?? [];
 				return {
 					items: rawItems.map((item) => mapFusionRequestResponse(item as FusionRequestFields)),
 					pagination: {
@@ -177,11 +196,12 @@ export function createGrpcApiClient(baseUrl: string, services: GrpcServiceDefs):
 		): Promise<FusionRequest> {
 			try {
 				const res = await callRpc(fusionClient, "respondToFusionRequest", {
-					id,
+					fusionRequestId: id,
 					response,
 					foodItemId,
 				});
-				return mapFusionRequestResponse(res as FusionRequestFields);
+				const wrapper = res as FusionRequestResponseWrapper;
+				return mapFusionRequestResponse((wrapper.fusionRequest ?? res) as FusionRequestFields);
 			} catch (error) {
 				throw toApiError(error);
 			}
@@ -222,6 +242,18 @@ function mapFusionRequestResponse(fields: FusionRequestFields): FusionRequest {
 		createdAt: String(fields.createdAt ?? ""),
 		updatedAt: String(fields.updatedAt ?? ""),
 	};
+}
+
+/**
+ * YYYY-MM-DD 形式の日付文字列を RFC 3339 形式に変換する。
+ * 既に RFC 3339 形式の場合はそのまま返す。
+ */
+function toRfc3339Date(dateStr: string): string {
+	if (!dateStr) return dateStr;
+	// 既に RFC 3339 形式（例: 2026-04-01T00:00:00Z）の場合はそのまま返す
+	if (dateStr.includes("T")) return dateStr;
+	// YYYY-MM-DD → RFC 3339（UTC 00:00:00）
+	return `${dateStr}T00:00:00Z`;
 }
 
 /** Connect エラーを ApiError に変換する。 */


### PR DESCRIPTION
## Summary

Codex レビューで検出された P1 x 5件 + P2 x 2件を一括修正。

- **P1-1 gRPC-Web フィールドマッピング不一致**: `respondToFusionRequest` が `id` を送信していたのを proto 定義通り `fusionRequestId` に修正。リストレスポンスも `items` -> `foodItems`/`fusionRequests` に修正。create レスポンスの wrapper unwrap を追加。
- **P1-2 承認UI が food_item_id 未送信**: 承認クリック時に `window.prompt` で食品アイテムIDを入力させ、`respondToRequest` に渡すよう修正。
- **P1-3 日付形式不一致 (YYYY-MM-DD vs RFC3339)**: `toRfc3339Date()` ヘルパーを追加し、`<input type="date">` の出力を `T00:00:00Z` 付きに変換してから gRPC 呼び出し。
- **P1-4/P2-2 生成コードの陳腐化**: `buf generate` で再生成し、proto に存在しない `CompleteFusionRequest` メソッド/メッセージを除去。
- **P1-5 単位不一致**: バックエンド `ValidUnits` に `"箱"` を追加（フロントエンド `FOOD_UNITS` と統一）。テストも追加。
- **P2-1 内部エラー情報公開**: gRPC エラーメッセージから Firestore/GCP 内部情報を除去。`log.Printf` で詳細をサーバーサイドに記録し、クライアントには汎用メッセージのみ返却。

## Test plan

- [x] `make check` 全パス (lint 0 issues, 59 frontend tests, 全 backend tests PASS)
- [x] `buf lint` パス
- [x] `CompleteFusionRequest` が生成コードから完全除去されていることを grep で確認
- [x] pre-commit hook (archgate, format-check, lint, test) 全パス