### PR TITLE
style(backend): gofumpt v0.10.0でinterceptor.goを整形しbackend CIを修復

### DIFF
--- a/backend/internal/auth/interceptor.go
+++ b/backend/internal/auth/interceptor.go
@@ -67,14 +67,16 @@ func UnaryInterceptor(verifier TokenVerifier) grpc.UnaryServerInterceptor {
 		// トークン検証
 		user, err := verifier.VerifyIDToken(ctx, token)
 		if err != nil {
-			slog.Warn("token verification failed",
+			slog.Warn(
+				"token verification failed",
 				"method", info.FullMethod,
 				"error", err,
 			)
 			return nil, status.Error(codes.Unauthenticated, "invalid or expired token")
 		}
 
-		slog.Debug("authenticated request",
+		slog.Debug(
+			"authenticated request",
 			"method", info.FullMethod,
 			"uid", user.UID,
 		)


### PR DESCRIPTION
## 概要
CIの `gofumpt@latest`（現在v0.10.0）が slog の複数行呼び出しで第一引数を独立行に置くルールを追加したため、`backend/internal/auth/interceptor.go` が format check で失敗し、**全dependabot PRのbackend CIをブロック**していた。

## 変更
- `slog.Warn(` / `slog.Debug(` の第一引数を独立行へ（gofumpt v0.10.0準拠）

## 検証（ローカル, CIと同一ツール）
- gofumpt v0.10.0: `-l` でクリーン
- golangci-lint v2.11.4: 0 issues
- go build / go test -race: 全パス
- frontend: oxlint/biome clean, vitest 64 passed

format-onlyの変更でロジック変更なし。