### PR TITLE
chore(deps): connect-es/protobuf-es を v2 系へ統合移行 (supersedes #48/#51/#69)

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -12,5 +12,6 @@ plugins:
     out: backend/gen
     opt: paths=source_relative
 
-  - remote: buf.build/connectrpc/es
+  - remote: buf.build/bufbuild/es:v2.12.1
     out: frontend/src/gen
+    opt: target=ts

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,9 @@
 			"name": "shokudo-nexus-frontend",
 			"version": "0.1.0",
 			"dependencies": {
-				"@bufbuild/protobuf": "^1.10.1",
-				"@connectrpc/connect": "^1.7.0",
-				"@connectrpc/connect-web": "^1.7.0",
+				"@bufbuild/protobuf": "^2.12.1",
+				"@connectrpc/connect": "^2.1.2",
+				"@connectrpc/connect-web": "^2.1.2",
 				"firebase": "^12.12.1",
 				"react": "^19.2.6",
 				"react-dom": "^19.2.7",
@@ -357,28 +357,28 @@
 			}
 		},
 		"node_modules/@bufbuild/protobuf": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
-			"integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+			"integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
 			"license": "(Apache-2.0 AND BSD-3-Clause)"
 		},
 		"node_modules/@connectrpc/connect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
-			"integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+			"integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@bufbuild/protobuf": "^1.10.0"
+				"@bufbuild/protobuf": "^2.7.0"
 			}
 		},
 		"node_modules/@connectrpc/connect-web": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.7.0.tgz",
-			"integrity": "sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.2.tgz",
+			"integrity": "sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@bufbuild/protobuf": "^1.10.0",
-				"@connectrpc/connect": "1.7.0"
+				"@bufbuild/protobuf": "^2.7.0",
+				"@connectrpc/connect": "2.1.2"
 			}
 		},
 		"node_modules/@csstools/color-helpers": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,9 +35,9 @@
 		"node": ">=22.0.0"
 	},
 	"dependencies": {
-		"@bufbuild/protobuf": "^1.10.1",
-		"@connectrpc/connect": "^1.7.0",
-		"@connectrpc/connect-web": "^1.7.0",
+		"@bufbuild/protobuf": "^2.12.1",
+		"@connectrpc/connect": "^2.1.2",
+		"@connectrpc/connect-web": "^2.1.2",
 		"firebase": "^12.12.1",
 		"react": "^19.2.6",
 		"react-dom": "^19.2.7",

--- a/frontend/src/lib/api-factory.ts
+++ b/frontend/src/lib/api-factory.ts
@@ -1,4 +1,4 @@
-import type { ServiceType } from "@bufbuild/protobuf";
+import type { DescService } from "@bufbuild/protobuf";
 import type { ApiClient } from "@/lib/api-client";
 import { createGrpcApiClient } from "@/lib/grpc-api-client";
 import { mockApiClient } from "@/lib/mock-api-client";
@@ -21,9 +21,9 @@ export function createApiClient(): ApiClient {
 }
 
 /** 生成コードモジュールの型。 */
-interface ServiceConnectModule {
-	FoodInventoryService: ServiceType;
-	FusionService: ServiceType;
+interface ServicePbModule {
+	FoodInventoryService: DescService;
+	FusionService: DescService;
 }
 
 /**
@@ -39,8 +39,8 @@ function createLazyGrpcClient(apiUrl: string): ApiClient {
 
 	async function getClient(): Promise<ApiClient> {
 		if (resolvedClient === null) {
-			const serviceConnectPath = "@/gen/shokudo/v1/service_connect";
-			const serviceModule = (await import(/* @vite-ignore */ serviceConnectPath)) as ServiceConnectModule;
+			const servicePbPath = "@/gen/shokudo/v1/service_pb";
+			const serviceModule = (await import(/* @vite-ignore */ servicePbPath)) as ServicePbModule;
 			resolvedClient = createGrpcApiClient(apiUrl, {
 				foodInventoryService: serviceModule.FoodInventoryService,
 				fusionService: serviceModule.FusionService,

--- a/frontend/src/lib/grpc-api-client.ts
+++ b/frontend/src/lib/grpc-api-client.ts
@@ -1,6 +1,6 @@
-import type { ServiceType } from "@bufbuild/protobuf";
+import type { DescService } from "@bufbuild/protobuf";
 import type { Interceptor } from "@connectrpc/connect";
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { createGrpcWebTransport } from "@connectrpc/connect-web";
 import type { ApiClient, ListFoodItemsResult, ListFusionRequestsResult } from "@/lib/api-client";
 import { ApiError } from "@/lib/api-client";
@@ -67,13 +67,13 @@ interface ListFusionRequestsResponseFields {
 
 /** サービス定義の注入パラメータ。gen ファイルへの直接依存を回避する。 */
 export interface GrpcServiceDefs {
-	readonly foodInventoryService: ServiceType;
-	readonly fusionService: ServiceType;
+	readonly foodInventoryService: DescService;
+	readonly fusionService: DescService;
 }
 
 /**
  * RPC メソッドを安全に呼び出すヘルパー。
- * createPromiseClient が返す Client<ServiceType> の各メソッドは
+ * createClient が返す Client<DescService> の各メソッドは
  * index signature 由来で undefined になりうるため、
  * 存在チェック付きで呼び出す。
  */
@@ -110,8 +110,8 @@ export function createGrpcApiClient(baseUrl: string, services: GrpcServiceDefs):
 		baseUrl,
 		interceptors: [authInterceptor],
 	});
-	const foodClient = createPromiseClient(services.foodInventoryService, transport) as unknown as RpcCaller;
-	const fusionClient = createPromiseClient(services.fusionService, transport) as unknown as RpcCaller;
+	const foodClient = createClient(services.foodInventoryService, transport) as unknown as RpcCaller;
+	const fusionClient = createClient(services.fusionService, transport) as unknown as RpcCaller;
 
 	return {
 		async createFoodItem(input: CreateFoodItemInput): Promise<FoodItem> {


### PR DESCRIPTION
## 概要
dependabot が個別提案した connect-es / protobuf-es の major 更新3件（#48 @connectrpc/connect, #51 @connectrpc/connect-web, #69 @bufbuild/protobuf）は、v2 が相互に依存し**生成コードの再生成も必要**なため、個別マージでは CI が通らない。本PRで統合対応する。

## 変更
| パッケージ | before | after |
|---|---|---|
| @bufbuild/protobuf | 1.10.1 | 2.12.1 |
| @connectrpc/connect | 1.7.0 | 2.1.2 |
| @connectrpc/connect-web | 1.7.0 | 2.1.2 |

- **buf.gen.yaml**: frontend生成を `buf.build/connectrpc/es`(protoc-gen-connect-es v1) から `buf.build/bufbuild/es:v2.12.1`(protoc-gen-es v2) へ。v2 では protoc-gen-connect-es が廃止され、サービス定義は `service_pb.ts` に統合生成される。
- **grpc-api-client.ts**: `createPromiseClient`→`createClient`、`ServiceType`→`DescService`
- **api-factory.ts**: 動的importパス `service_connect`→`service_pb`、型を `DescService` へ

## 検証（ローカル, CIと同一ツール）
- `buf generate`（protoc-gen-es v2.12.1）: `service_pb.ts` に FoodInventoryService/FusionService を GenService として生成
- `tsc --noEmit`: エラーなし
- oxlint / biome check: clean
- vitest: 64 passed

マージ後、#48/#51/#69 は superseded として根拠付きでクローズする。