### PR TITLE
feat: 調整パラメータの環境変数化・食品選択UI・ページネーション安定化

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,3 +9,12 @@ FIRESTORE_EMULATOR_HOST=localhost:8080
 # Structured Logging
 LOG_LEVEL=info   # info | debug
 LOG_FORMAT=text  # text | json
+
+# Service tuning parameters (matching / listing / validation)
+# 未設定・不正値の場合は以下のデフォルト値にフォールバックする。
+SHOKUDO_DEFAULT_PAGE_SIZE=20     # 一覧APIの既定ページサイズ
+SHOKUDO_MAX_PAGE_SIZE=100        # 一覧APIの最大ページサイズ
+SHOKUDO_MIN_QUANTITY=1           # 数量の下限（食品登録・融通リクエスト）
+SHOKUDO_MAX_QUANTITY=10000       # 数量の上限（食品登録・融通リクエスト）
+SHOKUDO_MAX_NAME_LENGTH=200      # 食品名の最大文字数
+SHOKUDO_MAX_MESSAGE_LENGTH=5000  # 融通リクエストメッセージの最大文字数

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,0 +1,101 @@
+// Package config はサービス層の調整可能なパラメータを環境変数から読み込む。
+//
+// マッチング・一覧・入力バリデーションの各しきい値をハードコードせず、運用環境
+// ごとに環境変数で調整できるようにする。環境変数が未設定または不正な場合は、
+// 従来のハードコード値と同じデフォルト値にフォールバックする。
+package config
+
+import (
+	"os"
+	"strconv"
+)
+
+// ServiceConfig はサービス層の調整可能なパラメータ。
+type ServiceConfig struct {
+	// DefaultPageSize は一覧APIでページサイズ未指定時に用いる既定値。
+	DefaultPageSize int
+	// MaxPageSize は一覧APIで許容する最大ページサイズ。
+	MaxPageSize int
+	// MinQuantity は数量の下限（食品登録・融通リクエスト共通）。
+	MinQuantity int32
+	// MaxQuantity は数量の上限（食品登録・融通リクエスト共通）。
+	MaxQuantity int32
+	// MaxNameLength は食品名の最大文字数。
+	MaxNameLength int
+	// MaxMessageLength は融通リクエストメッセージの最大文字数。
+	MaxMessageLength int
+}
+
+// デフォルト値。環境変数が未設定・不正な場合のフォールバックに用いる。
+const (
+	defaultDefaultPageSize  = 20
+	defaultMaxPageSize      = 100
+	defaultMinQuantity      = 1
+	defaultMaxQuantity      = 10000
+	defaultMaxNameLength    = 200
+	defaultMaxMessageLength = 5000
+)
+
+// 環境変数名。
+const (
+	envDefaultPageSize  = "SHOKUDO_DEFAULT_PAGE_SIZE"
+	envMaxPageSize      = "SHOKUDO_MAX_PAGE_SIZE"
+	envMinQuantity      = "SHOKUDO_MIN_QUANTITY"
+	envMaxQuantity      = "SHOKUDO_MAX_QUANTITY"
+	envMaxNameLength    = "SHOKUDO_MAX_NAME_LENGTH"
+	envMaxMessageLength = "SHOKUDO_MAX_MESSAGE_LENGTH"
+)
+
+// Default はすべてデフォルト値を持つ ServiceConfig を返す。テストや
+// 明示的にデフォルトを使いたい箇所で利用する。
+func Default() ServiceConfig {
+	return ServiceConfig{
+		DefaultPageSize:  defaultDefaultPageSize,
+		MaxPageSize:      defaultMaxPageSize,
+		MinQuantity:      defaultMinQuantity,
+		MaxQuantity:      defaultMaxQuantity,
+		MaxNameLength:    defaultMaxNameLength,
+		MaxMessageLength: defaultMaxMessageLength,
+	}
+}
+
+// LoadServiceConfig は環境変数から ServiceConfig を読み込む。
+// 各値が未設定・パース不能・非正の場合はデフォルト値にフォールバックする。
+func LoadServiceConfig() ServiceConfig {
+	return ServiceConfig{
+		DefaultPageSize:  getEnvInt(envDefaultPageSize, defaultDefaultPageSize),
+		MaxPageSize:      getEnvInt(envMaxPageSize, defaultMaxPageSize),
+		MinQuantity:      getEnvInt32(envMinQuantity, defaultMinQuantity),
+		MaxQuantity:      getEnvInt32(envMaxQuantity, defaultMaxQuantity),
+		MaxNameLength:    getEnvInt(envMaxNameLength, defaultMaxNameLength),
+		MaxMessageLength: getEnvInt(envMaxMessageLength, defaultMaxMessageLength),
+	}
+}
+
+// getEnvInt は環境変数を正の整数として読み込む。
+// 未設定・パース失敗・非正の値の場合は def を返す。
+func getEnvInt(key string, def int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		return def
+	}
+	return v
+}
+
+// getEnvInt32 は環境変数を正の int32 として読み込む。
+// 未設定・パース失敗・非正・範囲外の場合は def を返す。
+func getEnvInt32(key string, def int32) int32 {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || v <= 0 {
+		return def
+	}
+	return int32(v)
+}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,112 @@
+package config
+
+import "testing"
+
+func TestDefault(t *testing.T) {
+	cfg := Default()
+	if cfg.DefaultPageSize != 20 {
+		t.Errorf("DefaultPageSize: got %d, want 20", cfg.DefaultPageSize)
+	}
+	if cfg.MaxPageSize != 100 {
+		t.Errorf("MaxPageSize: got %d, want 100", cfg.MaxPageSize)
+	}
+	if cfg.MinQuantity != 1 {
+		t.Errorf("MinQuantity: got %d, want 1", cfg.MinQuantity)
+	}
+	if cfg.MaxQuantity != 10000 {
+		t.Errorf("MaxQuantity: got %d, want 10000", cfg.MaxQuantity)
+	}
+	if cfg.MaxNameLength != 200 {
+		t.Errorf("MaxNameLength: got %d, want 200", cfg.MaxNameLength)
+	}
+	if cfg.MaxMessageLength != 5000 {
+		t.Errorf("MaxMessageLength: got %d, want 5000", cfg.MaxMessageLength)
+	}
+}
+
+// clearConfigEnv は全設定の環境変数を空文字にし（=未設定扱い）、
+// 各テストがデフォルトから開始できるようにする。t.Setenv でテスト終了時に復元される。
+func clearConfigEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		envDefaultPageSize, envMaxPageSize, envMinQuantity,
+		envMaxQuantity, envMaxNameLength, envMaxMessageLength,
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func TestLoadServiceConfig_UsesDefaultsWhenUnset(t *testing.T) {
+	clearConfigEnv(t)
+	if got := LoadServiceConfig(); got != Default() {
+		t.Errorf("expected defaults, got %+v", got)
+	}
+}
+
+func TestLoadServiceConfig_ReadsEnv(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv(envDefaultPageSize, "10")
+	t.Setenv(envMaxPageSize, "50")
+	t.Setenv(envMinQuantity, "2")
+	t.Setenv(envMaxQuantity, "500")
+	t.Setenv(envMaxNameLength, "80")
+	t.Setenv(envMaxMessageLength, "1000")
+
+	cfg := LoadServiceConfig()
+	want := ServiceConfig{
+		DefaultPageSize:  10,
+		MaxPageSize:      50,
+		MinQuantity:      2,
+		MaxQuantity:      500,
+		MaxNameLength:    80,
+		MaxMessageLength: 1000,
+	}
+	if cfg != want {
+		t.Errorf("got %+v, want %+v", cfg, want)
+	}
+}
+
+func TestLoadServiceConfig_InvalidValuesFallBackToDefault(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"non-numeric", "abc"},
+		{"zero", "0"},
+		{"negative", "-5"},
+		{"float", "3.14"},
+		{"empty", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			t.Setenv(envMaxPageSize, tt.value)
+			if got := LoadServiceConfig().MaxPageSize; got != Default().MaxPageSize {
+				t.Errorf("MaxPageSize with %q: got %d, want default %d", tt.value, got, Default().MaxPageSize)
+			}
+		})
+	}
+}
+
+func TestLoadServiceConfig_Int32FieldsParse(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv(envMinQuantity, "3")
+	t.Setenv(envMaxQuantity, "9999")
+
+	cfg := LoadServiceConfig()
+	if cfg.MinQuantity != 3 {
+		t.Errorf("MinQuantity: got %d, want 3", cfg.MinQuantity)
+	}
+	if cfg.MaxQuantity != 9999 {
+		t.Errorf("MaxQuantity: got %d, want 9999", cfg.MaxQuantity)
+	}
+}
+
+func TestLoadServiceConfig_Int32OverflowFallsBack(t *testing.T) {
+	clearConfigEnv(t)
+	// int32 の範囲を超える値はデフォルトにフォールバックする。
+	t.Setenv(envMaxQuantity, "3000000000")
+	if got := LoadServiceConfig().MaxQuantity; got != Default().MaxQuantity {
+		t.Errorf("expected fallback to default %d for overflow, got %d", Default().MaxQuantity, got)
+	}
+}

--- a/backend/internal/repository/fooditem.go
+++ b/backend/internal/repository/fooditem.go
@@ -90,7 +90,12 @@ func (r *FoodItemRepository) List(ctx context.Context, params ListParams) (*List
 			Where("status", "in", activeStatuses)
 	}
 
-	q = q.OrderBy("created_at", firestore.Desc)
+	// created_at は複数ドキュメントで重複しうるため、ドキュメントID (__name__)
+	// を第2ソートキーとして明示的に付与し全順序を保証する。これによりカーソル
+	// ページネーションが安定し、一覧取得中にステータス更新（期限切れ反映）が
+	// 並行してもページトークンがずれず、重複・欠落が発生しない。
+	// created_at と __name__ はステータス更新で変化しない不変キーである。
+	q = q.OrderBy("created_at", firestore.Desc).OrderBy(firestore.DocumentID, firestore.Desc)
 
 	// ページトークンによるオフセット
 	if params.PageToken != "" {

--- a/backend/internal/repository/fooditem_test.go
+++ b/backend/internal/repository/fooditem_test.go
@@ -302,6 +302,68 @@ func TestFoodItemRepository_List_Pagination(t *testing.T) {
 	}
 }
 
+// TestFoodItemRepository_List_StablePaginationDuringExpiryUpdate は #38 の回帰テスト。
+// created_at が全アイテムで重複する状況で、一覧取得中に期限切れステータス更新を
+// 並行させても、ページトークンがずれず各アイテムがちょうど1回ずつ返ることを検証する。
+func TestFoodItemRepository_List_StablePaginationDuringExpiryUpdate(t *testing.T) {
+	ctx := context.Background()
+	repo := NewFoodItemRepository(newTestClient(t))
+
+	// 全アイテムを同一 created_at で作成し、ソートキーが一意でない状況を再現する。
+	sameTime := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	checkNow := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	pastExpiry := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	const total = 7
+	for i := range total {
+		item := newFoodItem("同時刻アイテム", "野菜", sameTime)
+		// 半数を期限切れ（ExpiryDate を過去）にして更新対象を作る。
+		if i%2 == 0 {
+			item.ExpiryDate = pastExpiry
+		}
+		if _, err := repo.Create(ctx, item); err != nil {
+			t.Fatalf("Create failed: %v", err)
+		}
+	}
+
+	// ページサイズ2で走査しつつ、取得した available かつ期限切れのアイテムを
+	// expired に更新する（ListFoodItems サービスのオンザフライ更新を模倣）。
+	seen := make(map[string]int)
+	pageToken := ""
+	pages := 0
+	for {
+		result, err := repo.List(ctx, ListParams{PageSize: 2, PageToken: pageToken})
+		if err != nil {
+			t.Fatalf("List failed: %v", err)
+		}
+		for _, item := range result.Items {
+			seen[item.ID]++
+			if item.Status == domain.FoodItemStatusAvailable && item.IsExpired(checkNow) {
+				item.Status = domain.FoodItemStatusExpired
+				if updErr := repo.Update(ctx, item); updErr != nil {
+					t.Fatalf("Update failed: %v", updErr)
+				}
+			}
+		}
+		pages++
+		if pages > total+3 {
+			t.Fatal("pagination did not terminate")
+		}
+		if result.NextPageToken == "" {
+			break
+		}
+		pageToken = result.NextPageToken
+	}
+
+	if len(seen) != total {
+		t.Errorf("expected %d unique items, got %d", total, len(seen))
+	}
+	for id, count := range seen {
+		if count != 1 {
+			t.Errorf("item %q returned %d times across pages, want exactly 1", id, count)
+		}
+	}
+}
+
 func TestFoodItemRepository_List_InvalidPageToken(t *testing.T) {
 	ctx := context.Background()
 	repo := NewFoodItemRepository(newTestClient(t))

--- a/backend/internal/repository/fusion_request.go
+++ b/backend/internal/repository/fusion_request.go
@@ -83,7 +83,9 @@ func (r *FusionRequestRepository) List(ctx context.Context, params FusionListPar
 		return nil, fmt.Errorf("failed to count fusion requests: %w", err)
 	}
 
-	q = q.OrderBy("created_at", firestore.Desc)
+	// created_at は重複しうるため、ドキュメントID (__name__) を第2ソートキーとして
+	// 明示的に付与し全順序を保証する。カーソルページネーションを安定させ、重複・欠落を防ぐ。
+	q = q.OrderBy("created_at", firestore.Desc).OrderBy(firestore.DocumentID, firestore.Desc)
 
 	if params.PageToken != "" {
 		tokenDoc, err := col.Doc(params.PageToken).Get(ctx)

--- a/backend/internal/service/food_inventory.go
+++ b/backend/internal/service/food_inventory.go
@@ -10,38 +10,34 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/akaitigo/shokudo-nexus/backend/internal/config"
 	"github.com/akaitigo/shokudo-nexus/backend/internal/domain"
 	"github.com/akaitigo/shokudo-nexus/backend/internal/repository"
 
 	pb "github.com/akaitigo/shokudo-nexus/backend/gen/shokudo/v1"
 )
 
-const (
-	defaultPageSize = 20
-	maxPageSize     = 100
-	maxNameLength   = 200
-	minQuantity     = 1
-	maxQuantity     = 10000
-)
-
 // FoodInventoryService はFoodInventoryServiceのgRPC実装。
 type FoodInventoryService struct {
 	pb.UnimplementedFoodInventoryServiceServer
 	repo    repository.FoodItemStore
+	cfg     config.ServiceConfig
 	nowFunc func() time.Time
 }
 
 // NewFoodInventoryService は新しいFoodInventoryServiceを生成する。
+// 調整可能なパラメータは環境変数から読み込む。
 func NewFoodInventoryService(repo repository.FoodItemStore) *FoodInventoryService {
 	return &FoodInventoryService{
 		repo:    repo,
+		cfg:     config.LoadServiceConfig(),
 		nowFunc: func() time.Time { return time.Now().UTC() },
 	}
 }
 
 // CreateFoodItem は余剰食品を登録する。
 func (s *FoodInventoryService) CreateFoodItem(ctx context.Context, req *pb.CreateFoodItemRequest) (*pb.CreateFoodItemResponse, error) {
-	if err := validateCreateFoodItemRequest(req); err != nil {
+	if err := validateCreateFoodItemRequest(req, s.cfg); err != nil {
 		return nil, err
 	}
 
@@ -105,10 +101,10 @@ func (s *FoodInventoryService) GetFoodItem(ctx context.Context, req *pb.GetFoodI
 func (s *FoodInventoryService) ListFoodItems(ctx context.Context, req *pb.ListFoodItemsRequest) (*pb.ListFoodItemsResponse, error) {
 	pageSize := int(req.GetPageSize())
 	if pageSize <= 0 {
-		pageSize = defaultPageSize
+		pageSize = s.cfg.DefaultPageSize
 	}
-	if pageSize > maxPageSize {
-		return nil, status.Errorf(codes.InvalidArgument, "page_size must be between 1 and %d", maxPageSize)
+	if pageSize > s.cfg.MaxPageSize {
+		return nil, status.Errorf(codes.InvalidArgument, "page_size must be between 1 and %d", s.cfg.MaxPageSize)
 	}
 
 	if req.GetCategoryFilter() != "" && !domain.IsValidCategory(req.GetCategoryFilter()) {
@@ -159,12 +155,12 @@ func (s *FoodInventoryService) DeleteFoodItem(ctx context.Context, req *pb.Delet
 	return &pb.DeleteFoodItemResponse{}, nil
 }
 
-func validateCreateFoodItemRequest(req *pb.CreateFoodItemRequest) error {
+func validateCreateFoodItemRequest(req *pb.CreateFoodItemRequest, cfg config.ServiceConfig) error {
 	if req.GetName() == "" {
 		return status.Error(codes.InvalidArgument, "name is required")
 	}
-	if utf8.RuneCountInString(req.GetName()) > maxNameLength {
-		return status.Errorf(codes.InvalidArgument, "name must be at most %d characters", maxNameLength)
+	if utf8.RuneCountInString(req.GetName()) > cfg.MaxNameLength {
+		return status.Errorf(codes.InvalidArgument, "name must be at most %d characters", cfg.MaxNameLength)
 	}
 	if !domain.IsValidCategory(req.GetCategory()) {
 		return status.Errorf(codes.InvalidArgument, "invalid category: %q", req.GetCategory())
@@ -172,8 +168,8 @@ func validateCreateFoodItemRequest(req *pb.CreateFoodItemRequest) error {
 	if req.GetExpiryDate() == "" {
 		return status.Error(codes.InvalidArgument, "expiry_date is required")
 	}
-	if req.GetQuantity() < minQuantity || req.GetQuantity() > maxQuantity {
-		return status.Errorf(codes.InvalidArgument, "quantity must be between %d and %d", minQuantity, maxQuantity)
+	if req.GetQuantity() < cfg.MinQuantity || req.GetQuantity() > cfg.MaxQuantity {
+		return status.Errorf(codes.InvalidArgument, "quantity must be between %d and %d", cfg.MinQuantity, cfg.MaxQuantity)
 	}
 	if !domain.IsValidUnit(req.GetUnit()) {
 		return status.Errorf(codes.InvalidArgument, "invalid unit: %q", req.GetUnit())

--- a/backend/internal/service/food_inventory_integration_test.go
+++ b/backend/internal/service/food_inventory_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/akaitigo/shokudo-nexus/backend/internal/config"
 	"github.com/akaitigo/shokudo-nexus/backend/internal/domain"
 	"github.com/akaitigo/shokudo-nexus/backend/internal/repository"
 
@@ -412,9 +413,10 @@ func TestListFoodItems_Success(t *testing.T) {
 
 func TestListFoodItems_DefaultPageSize(t *testing.T) {
 	mock := newMockFoodItemStore()
+	wantDefaultPageSize := config.Default().DefaultPageSize
 	mock.listFunc = func(_ context.Context, params repository.ListParams) (*repository.ListResult, error) {
-		if params.PageSize != defaultPageSize {
-			t.Errorf("expected default page size %d, got %d", defaultPageSize, params.PageSize)
+		if params.PageSize != wantDefaultPageSize {
+			t.Errorf("expected default page size %d, got %d", wantDefaultPageSize, params.PageSize)
 		}
 		return &repository.ListResult{Items: nil, TotalCount: 0}, nil
 	}

--- a/backend/internal/service/food_inventory_test.go
+++ b/backend/internal/service/food_inventory_test.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "github.com/akaitigo/shokudo-nexus/backend/gen/shokudo/v1"
+	"github.com/akaitigo/shokudo-nexus/backend/internal/config"
 )
 
 func TestValidateCreateFoodItemRequest(t *testing.T) {
@@ -22,7 +23,7 @@ func TestValidateCreateFoodItemRequest(t *testing.T) {
 	}
 
 	// 正常系
-	if err := validateCreateFoodItemRequest(validReq); err != nil {
+	if err := validateCreateFoodItemRequest(validReq, config.Default()); err != nil {
 		t.Errorf("expected nil error for valid request, got: %v", err)
 	}
 
@@ -83,7 +84,7 @@ func TestValidateCreateFoodItemRequest(t *testing.T) {
 			req := cloneCreateFoodItemRequest(validReq)
 			tt.modify(req)
 
-			err := validateCreateFoodItemRequest(req)
+			err := validateCreateFoodItemRequest(req, config.Default())
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -110,13 +111,13 @@ func TestValidateCreateFoodItemRequest_NameExact200Chars(t *testing.T) {
 		Quantity:   1,
 		Unit:       "kg",
 	}
-	if err := validateCreateFoodItemRequest(req); err != nil {
+	if err := validateCreateFoodItemRequest(req, config.Default()); err != nil {
 		t.Errorf("expected nil error for 200-char name, got: %v", err)
 	}
 }
 
 func TestGetFoodItem_EmptyID(t *testing.T) {
-	svc := &FoodInventoryService{}
+	svc := NewFoodInventoryService(newMockFoodItemStore())
 	_, err := svc.GetFoodItem(context.Background(), &pb.GetFoodItemRequest{Id: ""})
 	if err == nil {
 		t.Fatal("expected error for empty ID")
@@ -131,7 +132,7 @@ func TestGetFoodItem_EmptyID(t *testing.T) {
 }
 
 func TestDeleteFoodItem_EmptyID(t *testing.T) {
-	svc := &FoodInventoryService{}
+	svc := NewFoodInventoryService(newMockFoodItemStore())
 	_, err := svc.DeleteFoodItem(context.Background(), &pb.DeleteFoodItemRequest{Id: ""})
 	if err == nil {
 		t.Fatal("expected error for empty ID")
@@ -146,7 +147,7 @@ func TestDeleteFoodItem_EmptyID(t *testing.T) {
 }
 
 func TestListFoodItems_PageSizeTooLarge(t *testing.T) {
-	svc := &FoodInventoryService{}
+	svc := NewFoodInventoryService(newMockFoodItemStore())
 	_, err := svc.ListFoodItems(context.Background(), &pb.ListFoodItemsRequest{PageSize: 101})
 	if err == nil {
 		t.Fatal("expected error for page_size > 100")
@@ -161,7 +162,7 @@ func TestListFoodItems_PageSizeTooLarge(t *testing.T) {
 }
 
 func TestListFoodItems_InvalidCategoryFilter(t *testing.T) {
-	svc := &FoodInventoryService{}
+	svc := NewFoodInventoryService(newMockFoodItemStore())
 	_, err := svc.ListFoodItems(context.Background(), &pb.ListFoodItemsRequest{CategoryFilter: "invalid"})
 	if err == nil {
 		t.Fatal("expected error for invalid category filter")
@@ -183,5 +184,58 @@ func cloneCreateFoodItemRequest(r *pb.CreateFoodItemRequest) *pb.CreateFoodItemR
 		Quantity:   r.Quantity,
 		Unit:       r.Unit,
 		DonorId:    r.DonorId,
+	}
+}
+
+// --- 環境変数による調整パラメータの反映 (#34) ---
+
+func TestListFoodItems_RespectsConfiguredMaxPageSize(t *testing.T) {
+	t.Setenv("SHOKUDO_MAX_PAGE_SIZE", "5")
+	// コンストラクタが環境変数から設定を読み込む。
+	svc := NewFoodInventoryService(newMockFoodItemStore())
+
+	// 上限（5）を超える値は拒否される。
+	_, err := svc.ListFoodItems(context.Background(), &pb.ListFoodItemsRequest{PageSize: 6})
+	if err == nil {
+		t.Fatal("expected error for page_size above configured max, got nil")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", status.Code(err))
+	}
+
+	// 上限ちょうどは許容される。
+	if _, err := svc.ListFoodItems(context.Background(), &pb.ListFoodItemsRequest{PageSize: 5}); err != nil {
+		t.Errorf("expected page_size at configured max to be accepted, got: %v", err)
+	}
+}
+
+func TestCreateFoodItem_RespectsConfiguredMaxQuantity(t *testing.T) {
+	t.Setenv("SHOKUDO_MAX_QUANTITY", "50")
+	svc := NewFoodInventoryService(newMockFoodItemStore())
+
+	// 設定した上限（50）を超える数量は拒否される。
+	_, err := svc.CreateFoodItem(context.Background(), &pb.CreateFoodItemRequest{
+		Name:       "テスト",
+		Category:   "野菜",
+		ExpiryDate: "2026-04-15T00:00:00Z",
+		Quantity:   51,
+		Unit:       "kg",
+	})
+	if err == nil {
+		t.Fatal("expected error for quantity above configured max, got nil")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", status.Code(err))
+	}
+
+	// 上限以内は成功する。
+	if _, err := svc.CreateFoodItem(context.Background(), &pb.CreateFoodItemRequest{
+		Name:       "テスト",
+		Category:   "野菜",
+		ExpiryDate: "2026-04-15T00:00:00Z",
+		Quantity:   50,
+		Unit:       "kg",
+	}); err != nil {
+		t.Errorf("expected quantity within configured max to succeed, got: %v", err)
 	}
 }

--- a/backend/internal/service/fusion.go
+++ b/backend/internal/service/fusion.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/akaitigo/shokudo-nexus/backend/internal/config"
 	"github.com/akaitigo/shokudo-nexus/backend/internal/domain"
 	"github.com/akaitigo/shokudo-nexus/backend/internal/repository"
 
@@ -21,22 +22,25 @@ type FusionService struct {
 	pb.UnimplementedFusionServiceServer
 	fusionRepo   repository.FusionRequestStore
 	foodItemRepo repository.FoodItemStore
+	cfg          config.ServiceConfig
 	// approvalMu は承認処理のクリティカルセクションを保護し、
 	// 同一在庫の二重予約を防止する。
 	approvalMu sync.Mutex
 }
 
 // NewFusionService は新しいFusionServiceを生成する。
+// 調整可能なパラメータは環境変数から読み込む。
 func NewFusionService(fusionRepo repository.FusionRequestStore, foodItemRepo repository.FoodItemStore) *FusionService {
 	return &FusionService{
 		fusionRepo:   fusionRepo,
 		foodItemRepo: foodItemRepo,
+		cfg:          config.LoadServiceConfig(),
 	}
 }
 
 // CreateFusionRequest は食材融通リクエストを作成する。
 func (s *FusionService) CreateFusionRequest(ctx context.Context, req *pb.CreateFusionRequestRequest) (*pb.CreateFusionRequestResponse, error) {
-	if err := validateCreateFusionRequest(req); err != nil {
+	if err := validateCreateFusionRequest(req, s.cfg); err != nil {
 		return nil, err
 	}
 
@@ -67,10 +71,10 @@ func (s *FusionService) CreateFusionRequest(ctx context.Context, req *pb.CreateF
 func (s *FusionService) ListFusionRequests(ctx context.Context, req *pb.ListFusionRequestsRequest) (*pb.ListFusionRequestsResponse, error) {
 	pageSize := int(req.GetPageSize())
 	if pageSize <= 0 {
-		pageSize = defaultPageSize
+		pageSize = s.cfg.DefaultPageSize
 	}
-	if pageSize > maxPageSize {
-		return nil, status.Errorf(codes.InvalidArgument, "page_size must be between 1 and %d", maxPageSize)
+	if pageSize > s.cfg.MaxPageSize {
+		return nil, status.Errorf(codes.InvalidArgument, "page_size must be between 1 and %d", s.cfg.MaxPageSize)
 	}
 
 	if req.GetStatusFilter() != "" {
@@ -201,23 +205,21 @@ func (s *FusionService) RespondToFusionRequest(ctx context.Context, req *pb.Resp
 	}, nil
 }
 
-const maxMessageLength = 5000
-
-func validateCreateFusionRequest(req *pb.CreateFusionRequestRequest) error {
+func validateCreateFusionRequest(req *pb.CreateFusionRequestRequest, cfg config.ServiceConfig) error {
 	if req.GetRequesterShokudoId() == "" {
 		return status.Error(codes.InvalidArgument, "requester_shokudo_id is required")
 	}
 	if !domain.IsValidCategory(req.GetDesiredCategory()) {
 		return status.Errorf(codes.InvalidArgument, "invalid desired_category: %q", req.GetDesiredCategory())
 	}
-	if req.GetDesiredQuantity() < minQuantity || req.GetDesiredQuantity() > maxQuantity {
-		return status.Errorf(codes.InvalidArgument, "desired_quantity must be between %d and %d", minQuantity, maxQuantity)
+	if req.GetDesiredQuantity() < cfg.MinQuantity || req.GetDesiredQuantity() > cfg.MaxQuantity {
+		return status.Errorf(codes.InvalidArgument, "desired_quantity must be between %d and %d", cfg.MinQuantity, cfg.MaxQuantity)
 	}
 	if !domain.IsValidUnit(req.GetUnit()) {
 		return status.Errorf(codes.InvalidArgument, "invalid unit: %q", req.GetUnit())
 	}
-	if utf8.RuneCountInString(req.GetMessage()) > maxMessageLength {
-		return status.Errorf(codes.InvalidArgument, "message must be at most %d characters", maxMessageLength)
+	if utf8.RuneCountInString(req.GetMessage()) > cfg.MaxMessageLength {
+		return status.Errorf(codes.InvalidArgument, "message must be at most %d characters", cfg.MaxMessageLength)
 	}
 	return nil
 }

--- a/backend/internal/service/fusion_test.go
+++ b/backend/internal/service/fusion_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "github.com/akaitigo/shokudo-nexus/backend/gen/shokudo/v1"
+	"github.com/akaitigo/shokudo-nexus/backend/internal/config"
 	"github.com/akaitigo/shokudo-nexus/backend/internal/domain"
 )
 
@@ -23,7 +24,7 @@ func TestValidateCreateFusionRequest(t *testing.T) {
 		Message:            "にんじんが必要です",
 	}
 
-	if err := validateCreateFusionRequest(validReq); err != nil {
+	if err := validateCreateFusionRequest(validReq, config.Default()); err != nil {
 		t.Errorf("expected nil error for valid request, got: %v", err)
 	}
 
@@ -76,7 +77,7 @@ func TestValidateCreateFusionRequest(t *testing.T) {
 			}
 			tt.modify(req)
 
-			err := validateCreateFusionRequest(req)
+			err := validateCreateFusionRequest(req, config.Default())
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -181,7 +182,7 @@ func TestValidateRespondToFusionRequest(t *testing.T) {
 }
 
 func TestListFusionRequests_PageSizeTooLarge(t *testing.T) {
-	svc := &FusionService{}
+	svc := NewFusionService(newMockFusionRequestStore(), newMockFoodItemStore())
 	_, err := svc.ListFusionRequests(context.Background(), &pb.ListFusionRequestsRequest{PageSize: 101})
 	if err == nil {
 		t.Fatal("expected error for page_size > 100")
@@ -196,7 +197,7 @@ func TestListFusionRequests_PageSizeTooLarge(t *testing.T) {
 }
 
 func TestListFusionRequests_InvalidStatusFilter(t *testing.T) {
-	svc := &FusionService{}
+	svc := NewFusionService(newMockFusionRequestStore(), newMockFoodItemStore())
 	_, err := svc.ListFusionRequests(context.Background(), &pb.ListFusionRequestsRequest{StatusFilter: "invalid"})
 	if err == nil {
 		t.Fatal("expected error for invalid status filter")

--- a/frontend/src/components/fusion/FusionRequestList.test.tsx
+++ b/frontend/src/components/fusion/FusionRequestList.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { FusionRequestList } from "@/components/fusion/FusionRequestList";
 import type { ApiClient } from "@/lib/api-client";
 import { ApiClientProvider } from "@/lib/api-context";
-import type { FusionRequest } from "@/types/domain";
+import type { FoodItem, FusionRequest } from "@/types/domain";
 
 const mockRequests: FusionRequest[] = [
 	{
@@ -36,20 +36,65 @@ const mockRequests: FusionRequest[] = [
 	},
 ];
 
-function createMockClient(items: FusionRequest[] = mockRequests): ApiClient {
+// にんじん（野菜/kg/10）は fusion-0001（野菜/kg/5）に一致する。
+// レタス（数量3<5）と鶏肉（カテゴリ違い）は一致しない。
+const mockFoodItems: FoodItem[] = [
+	{
+		id: "food-veg-1",
+		name: "にんじん",
+		category: "野菜",
+		expiryDate: "2026-05-01",
+		quantity: 10,
+		unit: "kg",
+		donorId: "donor-1",
+		status: "available",
+		createdAt: "2026-03-30T00:00:00Z",
+		updatedAt: "2026-03-30T00:00:00Z",
+	},
+	{
+		id: "food-veg-2",
+		name: "レタス",
+		category: "野菜",
+		expiryDate: "2026-05-01",
+		quantity: 3,
+		unit: "kg",
+		donorId: "donor-1",
+		status: "available",
+		createdAt: "2026-03-30T00:00:00Z",
+		updatedAt: "2026-03-30T00:00:00Z",
+	},
+	{
+		id: "food-meat-1",
+		name: "鶏肉",
+		category: "肉",
+		expiryDate: "2026-05-01",
+		quantity: 10,
+		unit: "パック",
+		donorId: "donor-2",
+		status: "available",
+		createdAt: "2026-03-30T00:00:00Z",
+		updatedAt: "2026-03-30T00:00:00Z",
+	},
+];
+
+function createMockClient(overrides: Partial<ApiClient> = {}, requests: FusionRequest[] = mockRequests): ApiClient {
 	return {
 		createFoodItem: vi.fn(),
-		listFoodItems: vi.fn(),
+		listFoodItems: vi.fn().mockResolvedValue({
+			items: mockFoodItems,
+			pagination: { nextPageToken: "", totalCount: mockFoodItems.length },
+		}),
 		deleteFoodItem: vi.fn(),
 		createFusionRequest: vi.fn(),
 		listFusionRequests: vi.fn().mockResolvedValue({
-			items,
-			pagination: { nextPageToken: "", totalCount: items.length },
+			items: requests,
+			pagination: { nextPageToken: "", totalCount: requests.length },
 		}),
 		respondToFusionRequest: vi.fn().mockResolvedValue({
 			...mockRequests[0],
 			status: "approved",
 		}),
+		...overrides,
 	};
 }
 
@@ -112,8 +157,7 @@ describe("FusionRequestList", () => {
 		if (!secondRequest) {
 			throw new Error("mockRequests[1] is undefined");
 		}
-		const approvedOnly: FusionRequest[] = [{ ...secondRequest }];
-		renderList(createMockClient(approvedOnly));
+		renderList(createMockClient({}, [{ ...secondRequest }]));
 
 		await waitFor(() => {
 			expect(screen.getByText(/shokudo-002/)).toBeInTheDocument();
@@ -122,7 +166,7 @@ describe("FusionRequestList", () => {
 	});
 
 	it("リクエストがない場合にempty stateが表示される", async () => {
-		renderList(createMockClient([]));
+		renderList(createMockClient({}, []));
 
 		await waitFor(() => {
 			expect(screen.getByText("融通リクエストはありません")).toBeInTheDocument();
@@ -140,5 +184,109 @@ describe("FusionRequestList", () => {
 	it("新規リクエストリンクが表示される", () => {
 		renderList();
 		expect(screen.getByRole("link", { name: "新規リクエスト" })).toBeInTheDocument();
+	});
+
+	it("承認ボタンを押すと一致する食品アイテムの選択UIが表示される（window.promptは使わない）", async () => {
+		const user = userEvent.setup();
+		const promptSpy = vi.spyOn(window, "prompt");
+		const client = createMockClient();
+		renderList(client);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "承認" })).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole("button", { name: "承認" }));
+
+		// カテゴリでフィルタした食品一覧を取得する。
+		await waitFor(() => {
+			expect(client.listFoodItems).toHaveBeenCalledWith(20, "", "野菜");
+		});
+
+		const select = await screen.findByLabelText("提供する食品アイテム");
+		expect(select).toBeInTheDocument();
+		// 一致するアイテム（にんじん）のみが選択肢に出る。
+		expect(screen.getByRole("option", { name: /にんじん/ })).toBeInTheDocument();
+		expect(screen.queryByRole("option", { name: /レタス/ })).not.toBeInTheDocument();
+		expect(screen.queryByRole("option", { name: /鶏肉/ })).not.toBeInTheDocument();
+
+		// window.prompt は一切呼ばれない。
+		expect(promptSpy).not.toHaveBeenCalled();
+		promptSpy.mockRestore();
+	});
+
+	it("食品を選択して確定すると APPROVED で応答する", async () => {
+		const user = userEvent.setup();
+		const client = createMockClient();
+		renderList(client);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "承認" })).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole("button", { name: "承認" }));
+
+		const select = await screen.findByLabelText("提供する食品アイテム");
+		await user.selectOptions(select, "food-veg-1");
+		await user.click(screen.getByRole("button", { name: "確定" }));
+
+		await waitFor(() => {
+			expect(client.respondToFusionRequest).toHaveBeenCalledWith("fusion-0001", "APPROVED", "food-veg-1");
+		});
+	});
+
+	it("一致する食品がない場合はメッセージを表示し確定できない", async () => {
+		const user = userEvent.setup();
+		const client = createMockClient({
+			listFoodItems: vi.fn().mockResolvedValue({
+				items: [],
+				pagination: { nextPageToken: "", totalCount: 0 },
+			}),
+		});
+		renderList(client);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "承認" })).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole("button", { name: "承認" }));
+
+		await waitFor(() => {
+			expect(screen.getByText("承認可能な食品アイテムがありません")).toBeInTheDocument();
+		});
+		expect(screen.getByRole("button", { name: "確定" })).toBeDisabled();
+	});
+
+	it("拒否ボタンを押して拒否すると REJECTED で応答する", async () => {
+		const user = userEvent.setup();
+		const client = createMockClient();
+		renderList(client);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "拒否" })).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole("button", { name: "拒否" }));
+
+		expect(screen.getByText("このリクエストを拒否しますか？")).toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: "拒否する" }));
+
+		await waitFor(() => {
+			expect(client.respondToFusionRequest).toHaveBeenCalledWith("fusion-0001", "REJECTED", "");
+		});
+	});
+
+	it("キャンセルすると操作パネルが閉じる", async () => {
+		const user = userEvent.setup();
+		const client = createMockClient();
+		renderList(client);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "拒否" })).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole("button", { name: "拒否" }));
+		expect(screen.getByText("このリクエストを拒否しますか？")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+		expect(screen.queryByText("このリクエストを拒否しますか？")).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "拒否" })).toBeInTheDocument();
+		expect(client.respondToFusionRequest).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/components/fusion/FusionRequestList.tsx
+++ b/frontend/src/components/fusion/FusionRequestList.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import { useFoodItems } from "@/hooks/useFoodItems";
 import { useFusionRequests } from "@/hooks/useFusionRequests";
 import type { FusionRequest, FusionRequestStatus } from "@/types/domain";
 
@@ -25,6 +26,11 @@ const STATUS_FILTERS: readonly { value: string; label: string }[] = [
 	{ value: "completed", label: "完了" },
 ];
 
+interface FoodItemOption {
+	readonly id: string;
+	readonly label: string;
+}
+
 function formatDate(dateStr: string): string {
 	try {
 		const date = new Date(dateStr);
@@ -34,11 +40,20 @@ function formatDate(dateStr: string): string {
 	}
 }
 
+/** 承認・拒否操作の対象と種別。 */
+interface PendingAction {
+	readonly request: FusionRequest;
+	readonly type: "APPROVED" | "REJECTED";
+}
+
 /** 融通リクエスト一覧コンポーネント。 */
 export function FusionRequestList(): React.ReactElement {
 	const { items, totalCount, nextPageToken, loading, error, fetchRequests, respondToRequest } = useFusionRequests();
+	const { items: foodItems, loading: foodLoading, fetchItems: fetchFoodItems } = useFoodItems();
 	const [statusFilter, setStatusFilter] = useState("");
-	const [responding, setResponding] = useState<string | null>(null);
+	const [action, setAction] = useState<PendingAction | null>(null);
+	const [selectedFoodItemId, setSelectedFoodItemId] = useState("");
+	const [submitting, setSubmitting] = useState(false);
 
 	useEffect(() => {
 		void fetchRequests(statusFilter);
@@ -50,32 +65,71 @@ export function FusionRequestList(): React.ReactElement {
 		}
 	}, [statusFilter, nextPageToken, fetchRequests]);
 
-	const handleRespond = useCallback(
-		async (request: FusionRequest, response: "APPROVED" | "REJECTED") => {
-			let foodItemId = "";
-			if (response === "APPROVED") {
-				const input = window.prompt("提供する食品アイテムIDを入力してください:");
-				if (input === null) return;
-				foodItemId = input.trim();
-				if (!foodItemId) {
-					return;
-				}
-			}
-			const label = response === "APPROVED" ? "承認" : "拒否";
-			if (!window.confirm(`このリクエストを${label}しますか？`)) {
-				return;
-			}
-			setResponding(request.id);
-			try {
-				await respondToRequest(request.id, response, foodItemId);
-			} catch {
-				// エラーはフックで処理済み
-			} finally {
-				setResponding(null);
-			}
+	const closeAction = useCallback(() => {
+		setAction(null);
+		setSelectedFoodItemId("");
+	}, []);
+
+	// 承認操作を開始し、希望カテゴリに一致する食品アイテムを読み込む。
+	const openApprove = useCallback(
+		(request: FusionRequest) => {
+			setAction({ request, type: "APPROVED" });
+			setSelectedFoodItemId("");
+			void fetchFoodItems(request.desiredCategory);
 		},
-		[respondToRequest],
+		[fetchFoodItems],
 	);
+
+	const openReject = useCallback((request: FusionRequest) => {
+		setAction({ request, type: "REJECTED" });
+	}, []);
+
+	// 承認可能な食品アイテム: 在庫あり・希望カテゴリ/単位一致・数量充足のもの。
+	const foodItemOptions = useMemo<readonly FoodItemOption[]>(() => {
+		if (action?.type !== "APPROVED") {
+			return [];
+		}
+		const req = action.request;
+		return foodItems
+			.filter(
+				(item) =>
+					item.status === "available" &&
+					item.category === req.desiredCategory &&
+					item.unit === req.unit &&
+					item.quantity >= req.desiredQuantity,
+			)
+			.map((item) => ({ id: item.id, label: `${item.name}（${String(item.quantity)}${item.unit}）` }));
+	}, [foodItems, action]);
+
+	const confirmApprove = useCallback(async () => {
+		if (action === null || !selectedFoodItemId) {
+			return;
+		}
+		setSubmitting(true);
+		try {
+			await respondToRequest(action.request.id, "APPROVED", selectedFoodItemId);
+			closeAction();
+		} catch {
+			// エラーはフックで処理済み
+		} finally {
+			setSubmitting(false);
+		}
+	}, [action, selectedFoodItemId, respondToRequest, closeAction]);
+
+	const confirmReject = useCallback(async () => {
+		if (action === null) {
+			return;
+		}
+		setSubmitting(true);
+		try {
+			await respondToRequest(action.request.id, "REJECTED", "");
+			closeAction();
+		} catch {
+			// エラーはフックで処理済み
+		} finally {
+			setSubmitting(false);
+		}
+	}, [action, respondToRequest, closeAction]);
 
 	return (
 		<div>
@@ -129,26 +183,21 @@ export function FusionRequestList(): React.ReactElement {
 										<span className={STATUS_BADGE_CLASS[request.status]}>{STATUS_LABELS[request.status]}</span>
 									</div>
 								</div>
-								{request.status === "pending" ? (
-									<div className="data-item-actions">
-										<button
-											type="button"
-											className="btn btn-success btn-sm"
-											onClick={() => void handleRespond(request, "APPROVED")}
-											disabled={responding === request.id}
-										>
-											承認
-										</button>
-										<button
-											type="button"
-											className="btn btn-danger btn-sm"
-											onClick={() => void handleRespond(request, "REJECTED")}
-											disabled={responding === request.id}
-										>
-											拒否
-										</button>
-									</div>
-								) : null}
+								<RequestActions
+									request={request}
+									isActive={action?.request.id === request.id}
+									actionType={action?.type ?? null}
+									foodLoading={foodLoading}
+									foodItemOptions={foodItemOptions}
+									selectedFoodItemId={selectedFoodItemId}
+									submitting={submitting}
+									onOpenApprove={openApprove}
+									onOpenReject={openReject}
+									onSelectFood={setSelectedFoodItemId}
+									onConfirmApprove={() => void confirmApprove()}
+									onConfirmReject={() => void confirmReject()}
+									onCancel={closeAction}
+								/>
 							</div>
 						))}
 					</div>
@@ -163,5 +212,148 @@ export function FusionRequestList(): React.ReactElement {
 				</>
 			)}
 		</div>
+	);
+}
+
+/** pending リクエストの承認/拒否操作。開いていれば操作パネル、そうでなければ承認・拒否ボタンを表示する。 */
+function RequestActions({
+	request,
+	isActive,
+	actionType,
+	foodLoading,
+	foodItemOptions,
+	selectedFoodItemId,
+	submitting,
+	onOpenApprove,
+	onOpenReject,
+	onSelectFood,
+	onConfirmApprove,
+	onConfirmReject,
+	onCancel,
+}: {
+	readonly request: FusionRequest;
+	readonly isActive: boolean;
+	readonly actionType: "APPROVED" | "REJECTED" | null;
+	readonly foodLoading: boolean;
+	readonly foodItemOptions: readonly FoodItemOption[];
+	readonly selectedFoodItemId: string;
+	readonly submitting: boolean;
+	readonly onOpenApprove: (request: FusionRequest) => void;
+	readonly onOpenReject: (request: FusionRequest) => void;
+	readonly onSelectFood: (id: string) => void;
+	readonly onConfirmApprove: () => void;
+	readonly onConfirmReject: () => void;
+	readonly onCancel: () => void;
+}): React.ReactElement | null {
+	if (request.status !== "pending") {
+		return null;
+	}
+
+	if (!isActive) {
+		return (
+			<div className="data-item-actions">
+				<button type="button" className="btn btn-success btn-sm" onClick={() => onOpenApprove(request)}>
+					承認
+				</button>
+				<button type="button" className="btn btn-danger btn-sm" onClick={() => onOpenReject(request)}>
+					拒否
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="data-item-actions">
+			{actionType === "APPROVED" ? (
+				<ApprovePanel
+					foodLoading={foodLoading}
+					options={foodItemOptions}
+					selectedFoodItemId={selectedFoodItemId}
+					submitting={submitting}
+					onSelect={onSelectFood}
+					onConfirm={onConfirmApprove}
+					onCancel={onCancel}
+				/>
+			) : (
+				<RejectPanel submitting={submitting} onConfirm={onConfirmReject} onCancel={onCancel} />
+			)}
+		</div>
+	);
+}
+
+/** 承認時に提供する食品アイテムを選択するパネル。 */
+function ApprovePanel({
+	foodLoading,
+	options,
+	selectedFoodItemId,
+	submitting,
+	onSelect,
+	onConfirm,
+	onCancel,
+}: {
+	readonly foodLoading: boolean;
+	readonly options: readonly FoodItemOption[];
+	readonly selectedFoodItemId: string;
+	readonly submitting: boolean;
+	readonly onSelect: (id: string) => void;
+	readonly onConfirm: () => void;
+	readonly onCancel: () => void;
+}): React.ReactElement {
+	return (
+		<>
+			{foodLoading ? (
+				<span className="loading">読み込み中...</span>
+			) : options.length === 0 ? (
+				<span className="form-error">承認可能な食品アイテムがありません</span>
+			) : (
+				<select
+					className="form-select"
+					aria-label="提供する食品アイテム"
+					value={selectedFoodItemId}
+					onChange={(e) => onSelect(e.target.value)}
+				>
+					<option value="">選択してください</option>
+					{options.map((opt) => (
+						<option key={opt.id} value={opt.id}>
+							{opt.label}
+						</option>
+					))}
+				</select>
+			)}
+			<button
+				type="button"
+				className="btn btn-success btn-sm"
+				onClick={onConfirm}
+				disabled={submitting || !selectedFoodItemId}
+			>
+				確定
+			</button>
+			<button type="button" className="btn btn-outline btn-sm" onClick={onCancel} disabled={submitting}>
+				キャンセル
+			</button>
+		</>
+	);
+}
+
+/** 拒否の確認パネル。 */
+function RejectPanel({
+	submitting,
+	onConfirm,
+	onCancel,
+}: {
+	readonly submitting: boolean;
+	readonly onConfirm: () => void;
+	readonly onCancel: () => void;
+}): React.ReactElement {
+	return (
+		<>
+			<span>このリクエストを拒否しますか？</span>
+			<button type="button" className="btn btn-danger btn-sm" onClick={onConfirm} disabled={submitting}>
+				拒否する
+			</button>
+			<button type="button" className="btn btn-outline btn-sm" onClick={onCancel} disabled={submitting}>
+				キャンセル
+			</button>
+		</>
 	);
 }


### PR DESCRIPTION
## 概要

品質改善 Issue 3件（#34 / #33 / #38）をまとめて対応する。

## 変更内容

### #34 サービス調整パラメータの環境変数化
- `backend/internal/config` を新設し、ページサイズ・数量境界・文字数上限のハードコード値を環境変数化。
- **距離ベースのマッチングは現行 MVP のコードに存在しない**（マッチングはカテゴリ/単位/数量ベース）ため、Issue の趣旨「運用環境ごとに調整できない」を満たすべく、実在する一覧・マッチング・バリデーションのチューニング値を対象とした。
- 環境変数（`SHOKUDO_DEFAULT_PAGE_SIZE` / `SHOKUDO_MAX_PAGE_SIZE` / `SHOKUDO_MIN_QUANTITY` / `SHOKUDO_MAX_QUANTITY` / `SHOKUDO_MAX_NAME_LENGTH` / `SHOKUDO_MAX_MESSAGE_LENGTH`）。未設定・不正値・非正・範囲外はデフォルト（従来値）にフォールバック。
- `backend/.env.example` を更新。config のロード/境界テスト（カバレッジ100%）と、環境変数が実挙動に反映されることのサービステストを追加。

### #33 food_item_id 手入力の選択UI化
- `FusionRequestList` の承認時 `window.prompt`（ユーザーがIDを知り得ずUX破綻）を、希望カテゴリ/単位一致・数量充足の在庫から選ぶインライン選択UIに置換。
- 拒否も `window.confirm` からインライン確認に統一し、`prompt`/`confirm` を排除。
- 一致食品の絞り込み・選択→APPROVED応答・拒否→REJECTED応答・一致なし表示・キャンセル・prompt非呼び出しのテストを追加。

### #38 ListFoodItems ページネーションの Edge Case
- 調査の結果、期限切れ更新は `created_at` とドキュメントIDを変えないため順序に影響しないが、`created_at` は一意でない可能性がある。全順序を保証するため List クエリにドキュメントID (`__name__`) を第2ソートキーとして明示付与（自己文書化・暗黙依存の排除）。
- 同一 `created_at` のアイテムを一覧取得中に期限切れ更新しても、各アイテムがちょうど1回ずつ返る回帰テストを追加。

## 検証（ローカル実行済み）
- backend: `gofumpt -l`（差分なし）/ `golangci-lint run ./...`（0 issues）/ Firestore エミュレータ接続で `go test -race ./...` 全パス（config 100%, service 89.1%）/ `go build`
- frontend: `oxlint`（0）/ `biome check`（既存infoのみ, exit 0）/ `tsc --noEmit` / `vitest run`（7ファイル79テスト全パス）

Fixes #34
Fixes #33
Fixes #38